### PR TITLE
Add update instructions to Typefully skill

### DIFF
--- a/skills/typefully/SKILL.md
+++ b/skills/typefully/SKILL.md
@@ -23,7 +23,7 @@ Update methods by installation type:
 
 | Installation | How to update |
 |--------------|---------------|
-| CLI (`npx skills`) | `npx skills add typefully/agent-skills` |
+| CLI (`npx skills`) | `npx skills update` |
 | Claude Code plugin | `/plugin update typefully@typefully-skills` |
 | Cursor | Remote rules auto-sync from GitHub |
 | Manual | Pull latest from repo or re-copy `skills/typefully/` |


### PR DESCRIPTION
## Summary

Adds self-update awareness to the Typefully skill so users know how to keep it current with API changes:

- Add `last-updated` date to YAML frontmatter for freshness tracking
- Add freshness check instruction that prompts users when skill is 30+ days old
- Document update methods for each installation type (CLI, plugin, Cursor, manual)

Implements community feedback suggestions on keeping skills maintainable without blocking API releases.

Closes TYP-6670