### PR TITLE
Fix API settings URL and improve documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,41 @@ The `typefully.sh` script is a self-contained Bash CLI that wraps the Typefully 
 - **Authentication**: Requires `TYPEFULLY_API_KEY` environment variable
 - **API Base**: `https://api.typefully.com/v2`
 
-Key commands: `me`, `social-sets`, `social-set`, `draft:list`, `draft:get`, `draft:create`, `draft:update`, `draft:delete`, `schedule`, `publish`, `tag:list`, `tag:create`, `media:upload`, `media:status`
+### Commands
+
+#### User & Account Info
+| Command | Description |
+|---------|-------------|
+| `me` | Get authenticated user info |
+| `social-sets` | List all social sets (accounts) |
+| `social-set <id>` | Get social set details with connected platforms |
+
+#### Drafts
+| Command | Description |
+|---------|-------------|
+| `draft:list <social_set_id>` | List drafts |
+| `draft:get <social_set_id> <draft_id>` | Get a specific draft |
+| `draft:create <social_set_id>` | Create a new draft |
+| `draft:update <social_set_id> <draft_id>` | Update an existing draft |
+| `draft:delete <social_set_id> <draft_id>` | Delete a draft |
+
+#### Scheduling & Publishing
+| Command | Description |
+|---------|-------------|
+| `schedule <social_set_id> <draft_id>` | Schedule a draft for later |
+| `publish <social_set_id> <draft_id>` | Publish immediately |
+
+#### Tags
+| Command | Description |
+|---------|-------------|
+| `tag:list <social_set_id>` | List all tags |
+| `tag:create <social_set_id>` | Create a new tag |
+
+#### Media
+| Command | Description |
+|---------|-------------|
+| `media:upload <social_set_id> <file>` | Upload image/video, returns media_id |
+| `media:status <social_set_id> <media_id>` | Check if media is processed |
 
 All commands output JSON. The script uses strict mode (`set -euo pipefail`).
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 AI agent skills for drafting, scheduling, and managing social media posts across X, LinkedIn, Threads, Bluesky, and Mastodon. Give your AI agent the ability to manage your social media scheduling directly from your IDE or terminal.
 
-Built on the [Typefully API](https://typefully.com/docs/api). [Typefully](https://typefully.com) is a writing and scheduling app used by 200k+ top creators and teams to grow on X, LinkedIn, Threads, and Bluesky.
+Built on [Typefully](https://typefully.com), a writing and scheduling app used by 200k+ top creators and teams to grow on X, LinkedIn, Threads, and Bluesky. See the [API documentation](https://typefully.com/docs/api) for details.
 
 ## What Are Skills?
 
@@ -15,7 +15,7 @@ Skills are markdown files that give AI agents specialized knowledge and workflow
 ## Installation
 
 > [!NOTE]
-> Requires a Typefully API key. Get yours at https://typefully.com/settings/api and set it as an environment variable:
+> Requires a Typefully API key. Get yours at https://typefully.com/?settings=api and set it as an environment variable:
 >
 > ```bash
 > export TYPEFULLY_API_KEY=your_key_here
@@ -23,6 +23,7 @@ Skills are markdown files that give AI agents specialized knowledge and workflow
 
 > [!TIP]
 > To avoid being asked which account to use every time, add your default `social_set_id` to your project's `CLAUDE.md` or `AGENTS.md`:
+
 > ```markdown
 > ## Typefully
 > Default social_set_id: 12345
@@ -106,7 +107,7 @@ sudo apt-get install curl jq
 ### API errors (401, 403)
 
 - Verify your API key is correct
-- Check that your key has the required permissions at https://typefully.com/settings/api
+- Check that your key has the required permissions at https://typefully.com/?settings=api
 
 ### Drafts not appearing
 

--- a/skills/typefully/SKILL.md
+++ b/skills/typefully/SKILL.md
@@ -35,7 +35,7 @@ API changes ship independently—updating the skill ensures you have the latest 
 Before using this skill, ensure:
 
 1. **API Key**: Set the `TYPEFULLY_API_KEY` environment variable
-   - Get your key at https://typefully.com/settings/api
+   - Get your key at https://typefully.com/?settings=api
    - Export it: `export TYPEFULLY_API_KEY=your_key`
 
 2. **Dependencies**: `curl`, `jq`, and `perl` must be installed (perl is pre-installed on macOS and most Linux systems)

--- a/skills/typefully/scripts/typefully.sh
+++ b/skills/typefully/scripts/typefully.sh
@@ -16,7 +16,7 @@ command -v perl >/dev/null 2>&1 || { echo '{"error": "perl is required but not i
 # Check for API key (allow help without it)
 check_api_key() {
   if [[ -z "${TYPEFULLY_API_KEY:-}" ]]; then
-    echo '{"error": "TYPEFULLY_API_KEY environment variable is not set. Get your key at https://typefully.com/settings/api"}'
+    echo '{"error": "TYPEFULLY_API_KEY environment variable is not set. Get your key at https://typefully.com/?settings=api"}'
     exit 1
   fi
 }
@@ -161,7 +161,7 @@ EXAMPLES:
   ./typefully.sh draft:create 123 --platform x --text "Check out this image!" --media abc-123
 
 SETUP:
-  1. Get your API key from https://typefully.com/settings/api
+  1. Get your API key from https://typefully.com/?settings=api
   2. Export it: export TYPEFULLY_API_KEY=your_key_here
 EOF
 }


### PR DESCRIPTION
## Summary
- Fix incorrect API settings URL (`/settings/api` → `/?settings=api`) across all documentation and the CLI script
- Rephrase README intro to improve readability (two back-to-back links read awkwardly)
- Replace single-line command list in CLAUDE.md with organized tables for better scannability

## Files changed
- `README.md` - URL fix + intro rephrasing
- `CLAUDE.md` - URL fix + command tables
- `skills/typefully/SKILL.md` - URL fix
- `skills/typefully/scripts/typefully.sh` - URL fix in error message and help text