### PR TITLE
feat: add LinkedIn mentions support to Typefully CLI and skill

### DIFF
--- a/skills/typefully/CHANGELOG.md
+++ b/skills/typefully/CHANGELOG.md
@@ -13,6 +13,11 @@ The format is based on Keep a Changelog.
   - `queue:schedule:get [social_set_id]`
   - `queue:schedule:put [social_set_id] --rules '<json-array>'`
 - `queue:get` accepts both kebab-case and snake_case date flags (`--start-date/--end-date` and `--start_date/--end_date`).
+- LinkedIn mention resolver command:
+  - `linkedin:organizations:resolve [social_set_id] --organization-url <linkedin_company_or_school_url>`
+  - Also accepts `--organization_url` and `--url` aliases.
+  - Returns mention metadata including `mention_text` (for example `@[Typefully](urn:li:organization:86779668)`).
+- LinkedIn mention workflow documentation in `SKILL.md`, including mention syntax and resolver-to-draft examples.
 
 ### Fixed
 

--- a/skills/typefully/SKILL.md
+++ b/skills/typefully/SKILL.md
@@ -4,7 +4,7 @@ description: >
   Create, schedule, and manage social media posts via Typefully. ALWAYS use this
   skill when asked to draft, schedule, post, or check tweets, posts, threads, or
   social media content for Twitter/X, LinkedIn, Threads, Bluesky, or Mastodon.
-last-updated: 2026-02-19
+last-updated: 2026-02-26
 allowed-tools: Bash(./scripts/typefully.js:*)
 ---
 
@@ -109,6 +109,7 @@ When determining which social set to use:
 |--------------|--------|
 | "Draft a tweet about X" | `drafts:create --text "..."` (uses default social set) |
 | "Post this to LinkedIn" | `drafts:create --platform linkedin --text "..."` |
+| "Mention a company on LinkedIn" | `linkedin:organizations:resolve --organization-url "<linkedin_url>"` then use returned `mention_text` in `drafts:create` |
 | "Post to X and LinkedIn" (same content) | `drafts:create --platform x,linkedin --text "..."` |
 | "X thread + LinkedIn post" (different content) | Create one draft, then `drafts:update` to add platform (see [Publishing to Multiple Platforms](#publishing-to-multiple-platforms)) |
 | "What's scheduled?" | `drafts:list --status scheduled` |
@@ -200,6 +201,28 @@ Here's what we shipped and why it matters..." --use-default
 
 So make sure to NEVER create multiple drafts unless the user explicitly wants separate drafts for each platform.
 
+## LinkedIn Mentions
+
+LinkedIn mentions are supported via text syntax inside post content:
+
+```text
+@[Company Name](urn:li:organization:123456)
+```
+
+Use the resolver command to convert a public LinkedIn organization URL into ready-to-paste mention syntax:
+
+```bash
+# Resolve a LinkedIn URL into mention metadata
+./scripts/typefully.js linkedin:organizations:resolve --organization-url "https://www.linkedin.com/company/typefullycom/"
+# Returns mention_text like: @[Typefully](urn:li:organization:86779668)
+```
+
+Then include that `mention_text` in your LinkedIn draft text:
+
+```bash
+./scripts/typefully.js drafts:create --platform linkedin --text "Thanks @[Typefully](urn:li:organization:86779668) for the support."
+```
+
 ## Commands Reference
 
 ### User & Social Sets
@@ -209,6 +232,7 @@ So make sure to NEVER create multiple drafts unless the user explicitly wants se
 | `me:get` | Get authenticated user info |
 | `social-sets:list` | List all social sets you can access |
 | `social-sets:get <id>` | Get social set details including connected platforms |
+| `linkedin:organizations:resolve [social_set_id] --organization-url <url>` | Resolve LinkedIn company/school URL into mention metadata (`mention_text`, `urn`) |
 
 ### Drafts
 
@@ -318,6 +342,16 @@ Use `queue:get` when the user asks what is already scheduled (or free) for a giv
 ### Create a cross-platform post (specific platforms)
 ```bash
 ./scripts/typefully.js drafts:create --platform x,linkedin,threads --text "Big announcement!"
+```
+
+### Resolve LinkedIn mention syntax from a company URL
+```bash
+./scripts/typefully.js linkedin:organizations:resolve --organization-url "https://www.linkedin.com/company/typefullycom/"
+```
+
+### Create a LinkedIn draft with a mention
+```bash
+./scripts/typefully.js drafts:create --platform linkedin --text "Thanks @[Typefully](urn:li:organization:86779668) for the support."
 ```
 
 ### Create a post on all connected platforms
@@ -479,6 +513,7 @@ When in doubt, create drafts for user review rather than publishing directly.
 - **Smart platform default**: If `--platform` is omitted, the first connected platform is auto-selected
 - **All platforms**: Use `--all` to post to all connected platforms at once
 - **Character limits**: X (280), LinkedIn (3000), Threads (500), Bluesky (300), Mastodon (500)
+- **LinkedIn mentions**: Use `@[Name](urn:li:organization:ID)` in post text; resolve IDs via `linkedin:organizations:resolve`
 - **Thread creation**: Use `---` on its own line to split into multiple posts (thread)
 - **Scheduling**: Use `next-free-slot` to let Typefully pick the optimal time
 - **Cross-posting**: List multiple platforms separated by commas: `--platform x,linkedin`

--- a/skills/typefully/scripts/typefully.js
+++ b/skills/typefully/scripts/typefully.js
@@ -473,6 +473,25 @@ async function cmdSocialSetsGet(args) {
   output(data);
 }
 
+async function cmdLinkedInOrganizationsResolve(args) {
+  const parsed = parseArgs(args);
+  const socialSetId = resolveSocialSetIdFromParsed(parsed, parsed._positional[0]);
+  const organizationUrl = getRequiredStringArgFromParsed(
+    parsed,
+    'organization-url',
+    ['organization_url', 'url']
+  );
+
+  const params = new URLSearchParams();
+  params.set('organization_url', organizationUrl);
+
+  const data = await apiRequest(
+    'GET',
+    `/social-sets/${socialSetId}/linkedin/organizations/resolve?${params}`
+  );
+  output(data);
+}
+
 function prompt(question) {
   const rl = readline.createInterface({
     input: process.stdin,
@@ -1425,6 +1444,10 @@ COMMANDS:
 
   social-sets:list                           List all social sets
   social-sets:get [social_set_id]            Get social set details with platforms (uses default if ID omitted)
+  linkedin:organizations:resolve [social_set_id] [options]
+                                             Resolve LinkedIn organization URL for mention syntax
+    --organization-url <url>                 Public LinkedIn company/school URL
+                                             Also accepts: --organization_url / --url
 
   drafts:list [social_set_id] [options]      List drafts (uses default if ID omitted)
     --status <status>                        Filter by: draft, scheduled, published, error, publishing
@@ -1522,6 +1545,15 @@ EXAMPLES:
   # List all social sets
   ./typefully.js social-sets:list
 
+  # Resolve a LinkedIn URL to mention syntax
+  ./typefully.js linkedin:organizations:resolve 123 --organization-url "https://www.linkedin.com/company/typefullycom/"
+
+  # Same resolver using default social set
+  ./typefully.js linkedin:organizations:resolve --url "https://www.linkedin.com/company/typefullycom/"
+
+  # Use resolved mention syntax in a LinkedIn draft
+  ./typefully.js drafts:create 123 --platform linkedin --text "Thanks @[Typefully](urn:li:organization:86779668) for the support."
+
   # Create a tweet (uses default social set if configured)
   ./typefully.js drafts:create --text "Hello world!"
 
@@ -1603,6 +1635,7 @@ const COMMANDS = {
   'me:get': cmdMeGet,
   'social-sets:list': cmdSocialSetsList,
   'social-sets:get': cmdSocialSetsGet,
+  'linkedin:organizations:resolve': cmdLinkedInOrganizationsResolve,
   'drafts:list': cmdDraftsList,
   'drafts:get': cmdDraftsGet,
   'drafts:create': cmdDraftsCreate,

--- a/tests/social-sets.test.js
+++ b/tests/social-sets.test.js
@@ -5,6 +5,7 @@ const {
   withCliHarness,
   authAssertFactory,
   expectCliOk,
+  expectCliError,
 } = require('./typefully-cli.test-helpers');
 
 describe('social-sets:list', () => {
@@ -33,5 +34,69 @@ describe('social-sets:get', () => {
 
     const result = await run(['social-sets:get']);
     expectCliOk(result, { id: '222', platforms: { x: {} } });
+  }));
+});
+
+describe('linkedin:organizations:resolve', () => {
+  it('resolves organization URL with explicit social set', withCliHarness(async ({ server, apiKey, run }) => {
+    const organizationUrl = 'https://www.linkedin.com/company/typefullycom/';
+
+    server.expect('GET', '/v2/social-sets/222/linkedin/organizations/resolve', {
+      assert: (req) => {
+        authAssertFactory(apiKey)(req);
+        const q = new URL(`http://x${req.path}${req.search}`).searchParams;
+        assert.equal(q.get('organization_url'), organizationUrl);
+      },
+      json: {
+        id: '86779668',
+        urn: 'urn:li:organization:86779668',
+        mention_text: '@[Typefully](urn:li:organization:86779668)',
+      },
+    });
+
+    const result = await run([
+      'linkedin:organizations:resolve',
+      '222',
+      '--organization-url',
+      organizationUrl,
+    ]);
+    expectCliOk(result, {
+      id: '86779668',
+      urn: 'urn:li:organization:86779668',
+      mention_text: '@[Typefully](urn:li:organization:86779668)',
+    });
+  }));
+
+  it('uses default social set and supports --url alias', withCliHarness(async ({ server, apiKey, run, writeLocalConfig }) => {
+    const organizationUrl = 'https://www.linkedin.com/company/typefullycom/';
+    await writeLocalConfig({ defaultSocialSetId: '333' });
+
+    server.expect('GET', '/v2/social-sets/333/linkedin/organizations/resolve', {
+      assert: (req) => {
+        authAssertFactory(apiKey)(req);
+        const q = new URL(`http://x${req.path}${req.search}`).searchParams;
+        assert.equal(q.get('organization_url'), organizationUrl);
+      },
+      json: {
+        id: '86779668',
+        urn: 'urn:li:organization:86779668',
+        mention_text: '@[Typefully](urn:li:organization:86779668)',
+      },
+    });
+
+    const result = await run([
+      'linkedin:organizations:resolve',
+      '--url',
+      organizationUrl,
+    ]);
+    expectCliOk(result);
+  }));
+
+  it('requires organization URL before making requests', withCliHarness(async ({ server, run }) => {
+    const result = await run(['linkedin:organizations:resolve', '222']);
+    expectCliError(result, {
+      error: '--organization-url (or --organization_url, --url) is required',
+    });
+    assert.equal(server.requests.length, 0);
   }));
 });


### PR DESCRIPTION
## Summary
- add a new CLI command:   - `linkedin:organizations:resolve [social_set_id] --organization-url <url>`
  - supports `--organization_url` and `--url` aliases
- wire the command to Typefully API endpoint:  - `GET /v2/social-sets/{social_set_id}/linkedin/organizations/resolve`
- update CLI help/examples with LinkedIn mention workflow and mention syntax
- update `skills/typefully/SKILL.md` with LinkedIn mentions section, command reference, and examples
- bump SKILL frontmatter `last-updated` to `2026-02-26`
- add changelog entries in `skills/typefully/CHANGELOG.md`
- add tests for success/default-social-set/error cases in `tests/social-sets.test.js`

## Validation
- `npm run test:social-sets`
- `npm run test:all`
