### PR TITLE
feat(typefully): add X quote post URL support to drafts

### DIFF
--- a/skills/typefully/CHANGELOG.md
+++ b/skills/typefully/CHANGELOG.md
@@ -10,11 +10,23 @@ The format is based on Keep a Changelog.
 
 ### Added
 
+- `--quote-post-url <url>` (alias: `--quote-url`) for:
+  - `drafts:create`
+  - `drafts:update`
+- X quote-post payload support in draft create/update (`platforms.x.posts[].quote_post_url`).
+- CLI help/usage examples for creating and updating quote posts on X.
 - LinkedIn mention resolver command:
   - `linkedin:organizations:resolve [social_set_id] --organization-url <linkedin_company_or_school_url>`
   - Also accepts `--organization_url` and `--url` aliases.
   - Returns mention metadata including `mention_text` (for example `@[Typefully](urn:li:organization:86779668)`).
 - LinkedIn mention workflow documentation in `SKILL.md`, including mention syntax and resolver-to-draft examples.
+
+### Changed
+
+- Quote URLs are now pre-validated as X-only in the CLI:
+  - clear client-side error when quote flags are used without targeting X.
+  - unchanged behavior for non-quote draft create/update flows.
+- API `400 VALIDATION_ERROR` responses are surfaced as explicit validation messages in CLI output.
 
 ## [2026-02-19]
 

--- a/skills/typefully/SKILL.md
+++ b/skills/typefully/SKILL.md
@@ -250,9 +250,11 @@ All drafts commands support an optional `[social_set_id]` - if omitted, the conf
 | `drafts:create ... --media <media_ids>` | Create draft with attached media |
 | `drafts:create ... --reply-to <url>` | Reply to an existing X post |
 | `drafts:create ... --community <id>` | Post to an X community |
+| `drafts:create ... --quote-post-url <url>` | Quote an existing X post URL |
 | `drafts:create ... --share` | Generate a public share URL for the draft |
 | `drafts:create ... --scratchpad "..."` | Add internal notes/scratchpad to the draft |
 | `drafts:update [social_set_id] <draft_id> --text "..."` | Update an existing draft (single-arg requires `--use-default` if a default is configured) |
+| `drafts:update ... --quote-post-url <url>` | Update X post(s) in a draft to quote an existing post URL |
 | `drafts:update [social_set_id] <draft_id> --tags "tag1,tag2"` | Update tags on an existing draft (content unchanged) |
 | `drafts:update ... --share` | Generate a public share URL for the draft |
 | `drafts:update ... --scratchpad "..."` | Update internal notes/scratchpad |
@@ -397,6 +399,16 @@ Use `queue:get` when the user asks what is already scheduled (or free) for a giv
 ### Post to an X community
 ```bash
 ./scripts/typefully.js drafts:create --platform x --text "Community update" --community 1493446837214187523
+```
+
+### Create an X quote post
+```bash
+./scripts/typefully.js drafts:create --platform x --text "My take on this" --quote-post-url "https://x.com/user/status/1234567890123456789"
+```
+
+### Update a draft to quote an X post
+```bash
+./scripts/typefully.js drafts:update 456 --platform x --quote-post-url "https://x.com/user/status/1234567890123456789" --use-default
 ```
 
 ### Create draft with share URL


### PR DESCRIPTION
## TL;DR

- **Adds quote-post support for X drafts** via `--quote-post-url` (alias `--quote-url`) on both `drafts:create` and `drafts:update`, so CLI users can create/update quote posts without manual payload editing.
- **Prevents invalid non-X usage before API calls** by returning a clear CLI error when quote flags are used without targeting X, preserving existing non-quote behavior.
- **Improves validation feedback from API v2** by surfacing `400 VALIDATION_ERROR` responses as explicit validation messages in CLI output.
- **Updates docs and test coverage** (help text, examples, `SKILL.md`, changelog, and drafts tests) to keep behavior and guidance aligned.

This adds support for the `quote_post_url` field in Typefully API v2 create/update draft payloads while keeping backwards compatibility for existing create/update flows.

## Testing

- `npm test`
- `npm run test:drafts`