### PR TITLE
Add X post analytics support to the Typefully skill, including reply filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,16 @@ Ask your AI agent things like:
 - "Create a thread about [topic]"
 - "Post this to X and LinkedIn"
 
+## Local Development
+
+To test this skill locally, install it from the repo root:
+
+```bash
+npx skills add .
+```
+
+Then test it in your agent to verify the latest local changes behave as expected.
+
 ## Supported Platforms
 
 - X (formerly Twitter)

--- a/skills/typefully/CHANGELOG.md
+++ b/skills/typefully/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on Keep a Changelog.
 
 ## [Unreleased]
 
+### Added
+
+- `analytics:posts:list` now supports `--include-replies` (alias: `--include_replies`) to opt in to X reply posts.
+
+### Changed
+
+- `analytics:posts:list` now matches the backend analytics default: replies are excluded unless you explicitly pass `--include-replies`.
+- Analytics docs and examples now explain the non-reply default and the explicit reply-inclusion workflow.
+
 ## [2026-03-17]
 
 ### Added

--- a/skills/typefully/CHANGELOG.md
+++ b/skills/typefully/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on Keep a Changelog.
 
 ## [Unreleased]
 
+### Added
+
+- `analytics:posts:list [social_set_id] --start-date <YYYY-MM-DD> --end-date <YYYY-MM-DD>` to fetch X post analytics for an inclusive date range.
+- `analytics:posts:list` supports `--limit` / `--offset` pagination and `--start_date` / `--end_date` aliases.
+- Typefully skill docs now cover the X analytics workflow, command reference, examples, and metrics returned by the API.
+
+### Changed
+
+- `analytics:posts:list` now defaults `--platform` to `x` and returns a clear CLI error if another platform is requested, matching current API support.
+
 ## [2026-02-26]
 
 ### Added

--- a/skills/typefully/CHANGELOG.md
+++ b/skills/typefully/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on Keep a Changelog.
 
 ## [Unreleased]
 
+## [2026-03-17]
+
 ### Added
 
 - `analytics:posts:list [social_set_id] --start-date <YYYY-MM-DD> --end-date <YYYY-MM-DD>` to fetch X post analytics for an inclusive date range.

--- a/skills/typefully/SKILL.md
+++ b/skills/typefully/SKILL.md
@@ -4,7 +4,7 @@ description: >
   Create, schedule, and manage social media posts via Typefully. ALWAYS use this
   skill when asked to draft, schedule, post, or check tweets, posts, threads, or
   social media content for Twitter/X, LinkedIn, Threads, Bluesky, or Mastodon.
-last-updated: 2026-02-26
+last-updated: 2026-03-17
 allowed-tools: Bash(./scripts/typefully.js:*)
 ---
 
@@ -118,6 +118,7 @@ When determining which social set to use:
 | "Post this now" | `drafts:create ... --schedule now` or `drafts:publish <draft_id> --use-default` |
 | "Add notes/ideas to the draft" | `drafts:create ... --scratchpad "Your notes here"` |
 | "Check available tags" | `tags:list` |
+| "Show my X post analytics for last week" | `analytics:posts:list --start-date YYYY-MM-DD --end-date YYYY-MM-DD` |
 | "Show my queue for next week" | `queue:get --start-date YYYY-MM-DD --end-date YYYY-MM-DD` |
 
 ## Workflow
@@ -233,6 +234,23 @@ Then include that `mention_text` in your LinkedIn draft text:
 | `social-sets:list` | List all social sets you can access |
 | `social-sets:get <id>` | Get social set details including connected platforms |
 | `linkedin:organizations:resolve [social_set_id] --organization-url <url>` | Resolve LinkedIn company/school URL into mention metadata (`mention_text`, `urn`) |
+
+### Analytics
+
+All analytics commands support an optional `[social_set_id]` - if omitted, the configured default is used.
+
+The public API currently supports **X post analytics only** on this endpoint. The CLI defaults `--platform` to `x`, so you can usually omit it.
+
+Analytics responses return post-level metrics for the requested inclusive date range, including:
+- `impressions`
+- engagement totals and breakdowns like `likes`, `comments`, `shares`, `quotes`, `saves`, `profile_clicks`, and `link_clicks`
+
+| Command | Description |
+|---------|-------------|
+| `analytics:posts:list [social_set_id] --start-date <YYYY-MM-DD> --end-date <YYYY-MM-DD>` | List X posts with normalized analytics metrics for an inclusive date range |
+| `analytics:posts:list ... --start_date <YYYY-MM-DD> --end_date <YYYY-MM-DD>` | Snake case aliases for date flags (copied from API docs) |
+| `analytics:posts:list ... --limit 100 --offset 25` | Paginate through results |
+| `analytics:posts:list ... --platform x` | Explicitly request X analytics (currently the only supported platform) |
 
 ### Drafts
 
@@ -379,6 +397,16 @@ Use `queue:get` when the user asks what is already scheduled (or free) for a giv
 ### Get queue view for a date range
 ```bash
 ./scripts/typefully.js queue:get --start-date 2026-02-01 --end-date 2026-02-29
+```
+
+### Get X post analytics for a date range
+```bash
+./scripts/typefully.js analytics:posts:list --start-date 2026-03-01 --end-date 2026-03-07
+```
+
+### Paginate through X analytics results
+```bash
+./scripts/typefully.js analytics:posts:list --start-date 2026-03-01 --end-date 2026-03-31 --limit 100 --offset 100
 ```
 
 ### Get queue schedule
@@ -531,5 +559,6 @@ When in doubt, create drafts for user review rather than publishing directly.
 - **Cross-posting**: List multiple platforms separated by commas: `--platform x,linkedin`
 - **Draft titles**: Use `--title` for internal organization (not posted to social media)
 - **Draft scratchpad**: Use `--scratchpad` to attach notes to the draft in Typefully (NOT local files!) - perfect for thread ideas, research, context
+- **X analytics**: Use `analytics:posts:list --start-date ... --end-date ...` to fetch post metrics for a social set; the API currently supports only `x`
 - **Read from file**: Use `--file ./post.txt` instead of `--text` to read content from a file
 - **Sorting drafts**: Use `--sort` with values like `created_at`, `-created_at`, `scheduled_date`, etc.

--- a/skills/typefully/SKILL.md
+++ b/skills/typefully/SKILL.md
@@ -119,6 +119,7 @@ When determining which social set to use:
 | "Add notes/ideas to the draft" | `drafts:create ... --scratchpad "Your notes here"` |
 | "Check available tags" | `tags:list` |
 | "Show my X post analytics for last week" | `analytics:posts:list --start-date YYYY-MM-DD --end-date YYYY-MM-DD` |
+| "Show my X post analytics including replies" | `analytics:posts:list --start-date YYYY-MM-DD --end-date YYYY-MM-DD --include-replies` |
 | "Show my queue for next week" | `queue:get --start-date YYYY-MM-DD --end-date YYYY-MM-DD` |
 
 ## Workflow
@@ -241,6 +242,8 @@ All analytics commands support an optional `[social_set_id]` - if omitted, the c
 
 The public API currently supports **X post analytics only** on this endpoint. The CLI defaults `--platform` to `x`, so you can usually omit it.
 
+Replies are now **excluded by default** so the result set matches the main published-post view more closely. Add `--include-replies` when you explicitly want reply posts included.
+
 Analytics responses return post-level metrics for the requested inclusive date range, including:
 - `impressions`
 - engagement totals and breakdowns like `likes`, `comments`, `shares`, `quotes`, `saves`, `profile_clicks`, and `link_clicks`
@@ -249,6 +252,8 @@ Analytics responses return post-level metrics for the requested inclusive date r
 |---------|-------------|
 | `analytics:posts:list [social_set_id] --start-date <YYYY-MM-DD> --end-date <YYYY-MM-DD>` | List X posts with normalized analytics metrics for an inclusive date range |
 | `analytics:posts:list ... --start_date <YYYY-MM-DD> --end_date <YYYY-MM-DD>` | Snake case aliases for date flags (copied from API docs) |
+| `analytics:posts:list ... --include-replies` | Include X replies in the results (excluded by default) |
+| `analytics:posts:list ... --include_replies` | Snake case alias for the include-replies flag |
 | `analytics:posts:list ... --limit 100 --offset 25` | Paginate through results |
 | `analytics:posts:list ... --platform x` | Explicitly request X analytics (currently the only supported platform) |
 
@@ -402,6 +407,11 @@ Use `queue:get` when the user asks what is already scheduled (or free) for a giv
 ### Get X post analytics for a date range
 ```bash
 ./scripts/typefully.js analytics:posts:list --start-date 2026-03-01 --end-date 2026-03-07
+```
+
+### Get X post analytics including replies
+```bash
+./scripts/typefully.js analytics:posts:list --start-date 2026-03-01 --end-date 2026-03-07 --include-replies
 ```
 
 ### Paginate through X analytics results
@@ -559,6 +569,6 @@ When in doubt, create drafts for user review rather than publishing directly.
 - **Cross-posting**: List multiple platforms separated by commas: `--platform x,linkedin`
 - **Draft titles**: Use `--title` for internal organization (not posted to social media)
 - **Draft scratchpad**: Use `--scratchpad` to attach notes to the draft in Typefully (NOT local files!) - perfect for thread ideas, research, context
-- **X analytics**: Use `analytics:posts:list --start-date ... --end-date ...` to fetch post metrics for a social set; the API currently supports only `x`
+- **X analytics**: Use `analytics:posts:list --start-date ... --end-date ...` to fetch post metrics for a social set; replies are excluded by default, and `--include-replies` opts back in
 - **Read from file**: Use `--file ./post.txt` instead of `--text` to read content from a file
 - **Sorting drafts**: Use `--sort` with values like `created_at`, `-created_at`, `scheduled_date`, etc.

--- a/skills/typefully/scripts/typefully.js
+++ b/skills/typefully/scripts/typefully.js
@@ -554,6 +554,32 @@ async function cmdLinkedInOrganizationsResolve(args) {
   output(data);
 }
 
+async function cmdAnalyticsPostsList(args) {
+  const parsed = parseArgs(args);
+  const socialSetId = resolveSocialSetIdFromParsed(parsed, parsed._positional[0]);
+  const startDate = getRequiredStringArgFromParsed(parsed, 'start-date', ['start_date']);
+  const endDate = getRequiredStringArgFromParsed(parsed, 'end-date', ['end_date']);
+  const platform = (parsed.platform
+    ? coerceFlagValueToString(parsed.platform, '--platform')
+    : 'x').toLowerCase();
+
+  if (platform !== 'x') {
+    error('Only X analytics are currently supported by the Typefully API', {
+      provided_platform: platform,
+      hint: 'Use --platform x or omit the flag',
+    });
+  }
+
+  const params = new URLSearchParams();
+  params.set('start_date', startDate);
+  params.set('end_date', endDate);
+  if (parsed.limit) params.set('limit', parsed.limit);
+  if (parsed.offset) params.set('offset', parsed.offset);
+
+  const data = await apiRequest('GET', `/social-sets/${socialSetId}/analytics/${platform}/posts?${params}`);
+  output(data);
+}
+
 function prompt(question) {
   const rl = readline.createInterface({
     input: process.stdin,
@@ -1547,6 +1573,15 @@ COMMANDS:
                                              Resolve LinkedIn organization URL for mention syntax
     --organization-url <url>                 Public LinkedIn company/school URL
                                              Also accepts: --organization_url / --url
+  analytics:posts:list [social_set_id] [options]
+                                             List post analytics for a platform (uses default if ID omitted)
+    --platform <platform>                    Platform to query (default: x; currently only x is supported)
+    --start-date <YYYY-MM-DD>                Inclusive start date (required)
+                                             Also accepts: --start_date
+    --end-date <YYYY-MM-DD>                  Inclusive end date (required)
+                                             Also accepts: --end_date
+    --limit <n>                              Max results per page (default: 25, max: 100)
+    --offset <n>                             Number of results to skip (default: 0)
 
   drafts:list [social_set_id] [options]      List drafts (uses default if ID omitted)
     --status <status>                        Filter by: draft, scheduled, published, error, publishing
@@ -1652,6 +1687,12 @@ EXAMPLES:
   # Same resolver using default social set
   ./typefully.js linkedin:organizations:resolve --url "https://www.linkedin.com/company/typefullycom/"
 
+  # Fetch X post analytics for a date range
+  ./typefully.js analytics:posts:list 123 --start-date 2026-03-01 --end-date 2026-03-07
+
+  # Same analytics query using default social set
+  ./typefully.js analytics:posts:list --start-date 2026-03-01 --end-date 2026-03-07
+
   # Use resolved mention syntax in a LinkedIn draft
   ./typefully.js drafts:create 123 --platform linkedin --text "Thanks @[Typefully](urn:li:organization:86779668) for the support."
 
@@ -1743,6 +1784,7 @@ const COMMANDS = {
   'social-sets:list': cmdSocialSetsList,
   'social-sets:get': cmdSocialSetsGet,
   'linkedin:organizations:resolve': cmdLinkedInOrganizationsResolve,
+  'analytics:posts:list': cmdAnalyticsPostsList,
   'drafts:list': cmdDraftsList,
   'drafts:get': cmdDraftsGet,
   'drafts:create': cmdDraftsCreate,

--- a/skills/typefully/scripts/typefully.js
+++ b/skills/typefully/scripts/typefully.js
@@ -555,13 +555,14 @@ async function cmdLinkedInOrganizationsResolve(args) {
 }
 
 async function cmdAnalyticsPostsList(args) {
-  const parsed = parseArgs(args);
+  const parsed = parseArgs(args, { 'include-replies': 'boolean', 'include_replies': 'boolean' });
   const socialSetId = resolveSocialSetIdFromParsed(parsed, parsed._positional[0]);
   const startDate = getRequiredStringArgFromParsed(parsed, 'start-date', ['start_date']);
   const endDate = getRequiredStringArgFromParsed(parsed, 'end-date', ['end_date']);
   const platform = (parsed.platform
     ? coerceFlagValueToString(parsed.platform, '--platform')
     : 'x').toLowerCase();
+  const includeReplies = Boolean(parsed['include-replies'] || parsed.include_replies);
 
   if (platform !== 'x') {
     error('Only X analytics are currently supported by the Typefully API', {
@@ -575,6 +576,7 @@ async function cmdAnalyticsPostsList(args) {
   params.set('end_date', endDate);
   if (parsed.limit) params.set('limit', parsed.limit);
   if (parsed.offset) params.set('offset', parsed.offset);
+  if (includeReplies) params.set('include_replies', 'true');
 
   const data = await apiRequest('GET', `/social-sets/${socialSetId}/analytics/${platform}/posts?${params}`);
   output(data);
@@ -1580,6 +1582,7 @@ COMMANDS:
                                              Also accepts: --start_date
     --end-date <YYYY-MM-DD>                  Inclusive end date (required)
                                              Also accepts: --end_date
+    --include-replies, --include_replies     Include X replies in results (excluded by default)
     --limit <n>                              Max results per page (default: 25, max: 100)
     --offset <n>                             Number of results to skip (default: 0)
 
@@ -1692,6 +1695,9 @@ EXAMPLES:
 
   # Same analytics query using default social set
   ./typefully.js analytics:posts:list --start-date 2026-03-01 --end-date 2026-03-07
+
+  # Include replies in X analytics results
+  ./typefully.js analytics:posts:list --start-date 2026-03-01 --end-date 2026-03-07 --include-replies
 
   # Use resolved mention syntax in a LinkedIn draft
   ./typefully.js drafts:create 123 --platform linkedin --text "Thanks @[Typefully](urn:li:organization:86779668) for the support."


### PR DESCRIPTION
## Summary
- add `analytics:posts:list` to `skills/typefully/scripts/typefully.js`
- add `--include-replies` / `--include_replies` so clients can opt back in to X replies explicitly
- document the X analytics workflow and reply-filter behavior in `skills/typefully/SKILL.md`
- add user-facing changelog entries in `skills/typefully/CHANGELOG.md`

## Why
Typefully API v2 now exposes X post analytics by date range, and backend PR `typefully/typefully-backend#1476` changes the default result set to exclude replies unless `include_replies=true` is sent. The public skill/CLI should match that behavior and expose the opt-in path directly.

## Validation
- `node -c skills/typefully/scripts/typefully.js`
- `node skills/typefully/scripts/typefully.js help | rg -n "analytics:posts:list|include-replies|include_replies" -S`
- `node skills/typefully/scripts/typefully.js analytics:posts:list --include_replies --end_date 2026-03-17`
- `node skills/typefully/scripts/typefully.js analytics:posts:list 123 --platform linkedin --include-replies --start-date 2026-03-10 --end-date 2026-03-17`