### PR TITLE
Update Typefully skill for recent API v2 features

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "test:media": "vitest run tests/media.test.js",
     "test:queue": "vitest run tests/queue.test.js",
     "test:config": "vitest run tests/config.test.js",
+    "test:analytics": "vitest run tests/analytics.test.js",
     "test:social-sets": "vitest run tests/social-sets.test.js",
     "test:tags": "vitest run tests/tags.test.js",
     "test:me": "vitest run tests/me.test.js",

--- a/skills/typefully/CHANGELOG.md
+++ b/skills/typefully/CHANGELOG.md
@@ -8,12 +8,15 @@ The format is based on Keep a Changelog.
 
 ### Added
 
+- `analytics:followers:get [social_set_id]` to fetch X follower analytics, with optional `--start-date` / `--end-date` date filters and snake_case aliases.
 - `analytics:posts:list` now supports `--include-replies` (alias: `--include_replies`) to opt in to X reply posts.
+- `--paid-partnership` / `--paid_partnership` and `--made-with-ai` / `--made_with_ai` for X draft create/update disclosure flags.
+- Typefully skill docs now explain how to check `publishing_quota` with `social-sets:get`.
 
 ### Changed
 
 - `analytics:posts:list` now matches the backend analytics default: replies are excluded unless you explicitly pass `--include-replies`.
-- Analytics docs and examples now explain the non-reply default and the explicit reply-inclusion workflow.
+- Analytics docs and examples now explain X post analytics, X follower analytics, and the explicit reply-inclusion workflow.
 
 ## [2026-03-17]
 

--- a/skills/typefully/SKILL.md
+++ b/skills/typefully/SKILL.md
@@ -4,7 +4,7 @@ description: >
   Create, schedule, and manage social media posts via Typefully. ALWAYS use this
   skill when asked to draft, schedule, post, or check tweets, posts, threads, or
   social media content for Twitter/X, LinkedIn, Threads, Bluesky, or Mastodon.
-last-updated: 2026-03-17
+last-updated: 2026-04-24
 allowed-tools: Bash(./scripts/typefully.js:*)
 ---
 
@@ -118,8 +118,10 @@ When determining which social set to use:
 | "Post this now" | `drafts:create ... --schedule now` or `drafts:publish <draft_id> --use-default` |
 | "Add notes/ideas to the draft" | `drafts:create ... --scratchpad "Your notes here"` |
 | "Check available tags" | `tags:list` |
+| "Check my publishing quota" | `social-sets:get` and inspect `publishing_quota` |
 | "Show my X post analytics for last week" | `analytics:posts:list --start-date YYYY-MM-DD --end-date YYYY-MM-DD` |
 | "Show my X post analytics including replies" | `analytics:posts:list --start-date YYYY-MM-DD --end-date YYYY-MM-DD --include-replies` |
+| "Show my X follower growth" | `analytics:followers:get --start-date YYYY-MM-DD --end-date YYYY-MM-DD` |
 | "Show my queue for next week" | `queue:get --start-date YYYY-MM-DD --end-date YYYY-MM-DD` |
 
 ## Workflow
@@ -233,20 +235,29 @@ Then include that `mention_text` in your LinkedIn draft text:
 |---------|-------------|
 | `me:get` | Get authenticated user info |
 | `social-sets:list` | List all social sets you can access |
-| `social-sets:get <id>` | Get social set details including connected platforms |
+| `social-sets:get <id>` | Get social set details including connected platforms and `publishing_quota` |
 | `linkedin:organizations:resolve [social_set_id] --organization-url <url>` | Resolve LinkedIn company/school URL into mention metadata (`mention_text`, `urn`) |
+
+`social-sets:get` returns a `publishing_quota` object when available:
+- `used` - published drafts already counted in the current quota window
+- `remaining` - remaining publish slots, or `"unlimited"`
+- `resets_at` - when the current quota window resets
+
+Use it before publishing/scheduling when the user asks about remaining posting capacity or when a publish/schedule request fails with quota copy.
 
 ### Analytics
 
 All analytics commands support an optional `[social_set_id]` - if omitted, the configured default is used.
 
-The public API currently supports **X post analytics only** on this endpoint. The CLI defaults `--platform` to `x`, so you can usually omit it.
+The public API currently supports **X analytics only** on these endpoints. The CLI defaults `--platform` to `x`, so you can usually omit it.
 
 Replies are now **excluded by default** so the result set matches the main published-post view more closely. Add `--include-replies` when you explicitly want reply posts included.
 
 Analytics responses return post-level metrics for the requested inclusive date range, including:
 - `impressions`
 - engagement totals and breakdowns like `likes`, `comments`, `shares`, `quotes`, `saves`, `profile_clicks`, and `link_clicks`
+
+Follower analytics returns `current_followers_count` plus daily `data` points with `date` and `followers_count`. If you omit dates, the API returns the default recent range.
 
 | Command | Description |
 |---------|-------------|
@@ -256,6 +267,10 @@ Analytics responses return post-level metrics for the requested inclusive date r
 | `analytics:posts:list ... --include_replies` | Snake case alias for the include-replies flag |
 | `analytics:posts:list ... --limit 100 --offset 25` | Paginate through results |
 | `analytics:posts:list ... --platform x` | Explicitly request X analytics (currently the only supported platform) |
+| `analytics:followers:get [social_set_id]` | Get X follower counts for the API default date range |
+| `analytics:followers:get ... --start-date <YYYY-MM-DD> --end-date <YYYY-MM-DD>` | Get X follower counts for an inclusive date range |
+| `analytics:followers:get ... --start_date <YYYY-MM-DD> --end_date <YYYY-MM-DD>` | Snake case aliases for date flags |
+| `analytics:followers:get ... --platform x` | Explicitly request X followers analytics (currently the only supported platform) |
 
 ### Drafts
 
@@ -274,10 +289,14 @@ All drafts commands support an optional `[social_set_id]` - if omitted, the conf
 | `drafts:create ... --reply-to <url>` | Reply to an existing X post |
 | `drafts:create ... --community <id>` | Post to an X community |
 | `drafts:create ... --quote-post-url <url>` | Quote an existing X post URL |
+| `drafts:create ... --paid-partnership` | Label X post(s) as paid partnership |
+| `drafts:create ... --made-with-ai` | Label X post(s) as made with AI |
 | `drafts:create ... --share` | Generate a public share URL for the draft |
 | `drafts:create ... --scratchpad "..."` | Add internal notes/scratchpad to the draft |
 | `drafts:update [social_set_id] <draft_id> --text "..."` | Update an existing draft (single-arg requires `--use-default` if a default is configured) |
 | `drafts:update ... --quote-post-url <url>` | Update X post(s) in a draft to quote an existing post URL |
+| `drafts:update ... --paid-partnership` | Label existing or updated X post(s) as paid partnership |
+| `drafts:update ... --made-with-ai` | Label existing or updated X post(s) as made with AI |
 | `drafts:update [social_set_id] <draft_id> --tags "tag1,tag2"` | Update tags on an existing draft (content unchanged) |
 | `drafts:update ... --share` | Generate a public share URL for the draft |
 | `drafts:update ... --scratchpad "..."` | Update internal notes/scratchpad |
@@ -419,6 +438,16 @@ Use `queue:get` when the user asks what is already scheduled (or free) for a giv
 ./scripts/typefully.js analytics:posts:list --start-date 2026-03-01 --end-date 2026-03-31 --limit 100 --offset 100
 ```
 
+### Get X followers analytics for the default range
+```bash
+./scripts/typefully.js analytics:followers:get
+```
+
+### Get X followers analytics for a date range
+```bash
+./scripts/typefully.js analytics:followers:get --start-date 2026-03-01 --end-date 2026-03-31
+```
+
 ### Get queue schedule
 ```bash
 ./scripts/typefully.js queue:schedule:get
@@ -444,9 +473,19 @@ Use `queue:get` when the user asks what is already scheduled (or free) for a giv
 ./scripts/typefully.js drafts:create --platform x --text "My take on this" --quote-post-url "https://x.com/user/status/1234567890123456789"
 ```
 
+### Create an X post with content disclosure labels
+```bash
+./scripts/typefully.js drafts:create --platform x --text "Sponsored AI-assisted update" --paid-partnership --made-with-ai
+```
+
 ### Update a draft to quote an X post
 ```bash
 ./scripts/typefully.js drafts:update 456 --platform x --quote-post-url "https://x.com/user/status/1234567890123456789" --use-default
+```
+
+### Add an X content disclosure label to an existing draft
+```bash
+./scripts/typefully.js drafts:update 456 --made-with-ai --use-default
 ```
 
 ### Create draft with share URL
@@ -570,5 +609,8 @@ When in doubt, create drafts for user review rather than publishing directly.
 - **Draft titles**: Use `--title` for internal organization (not posted to social media)
 - **Draft scratchpad**: Use `--scratchpad` to attach notes to the draft in Typefully (NOT local files!) - perfect for thread ideas, research, context
 - **X analytics**: Use `analytics:posts:list --start-date ... --end-date ...` to fetch post metrics for a social set; replies are excluded by default, and `--include-replies` opts back in
+- **X followers analytics**: Use `analytics:followers:get --start-date ... --end-date ...` to fetch daily follower counts, or omit dates for the API default range
+- **X content disclosures**: Use `--paid-partnership` and/or `--made-with-ai` on `drafts:create` or `drafts:update`; these flags are X-only and are applied only to X posts
+- **Publishing quota**: Use `social-sets:get` and inspect `publishing_quota` to see remaining publish capacity and reset time
 - **Read from file**: Use `--file ./post.txt` instead of `--text` to read content from a file
 - **Sorting drafts**: Use `--sort` with values like `created_at`, `-created_at`, `scheduled_date`, etc.

--- a/skills/typefully/scripts/typefully.js
+++ b/skills/typefully/scripts/typefully.js
@@ -389,6 +389,40 @@ function addQuotePostUrl(posts, quotePostUrl) {
   return posts.map(post => ({ ...post, quote_post_url: quotePostUrl }));
 }
 
+function getXContentDisclosuresFromParsed(parsed) {
+  const paidPartnership = Boolean(parsed['paid-partnership'] || parsed.paid_partnership);
+  const madeWithAi = Boolean(parsed['made-with-ai'] || parsed.made_with_ai);
+
+  return {
+    paidPartnership,
+    madeWithAi,
+    hasAny: paidPartnership || madeWithAi,
+  };
+}
+
+function addXContentDisclosures(posts, disclosures) {
+  if (!disclosures.hasAny) return posts;
+  return posts.map(post => {
+    const updated = { ...post };
+    if (disclosures.paidPartnership) {
+      updated.paid_partnership = true;
+    }
+    if (disclosures.madeWithAi) {
+      updated.made_with_ai = true;
+    }
+    return updated;
+  });
+}
+
+function validateXOnlyPostOptions(platformList, { quotePostUrl, disclosures }) {
+  if ((quotePostUrl || disclosures.hasAny) && !platformList.includes('x')) {
+    if (quotePostUrl) {
+      error('--quote-post-url is only supported for X posts. Include x in --platform or remove the quote flag.');
+    }
+    error('--paid-partnership/--made-with-ai is only supported for X posts. Include x in --platform or remove the X-only flag.');
+  }
+}
+
 function parseCsvArg(value, flagName) {
   // parseArgs sets missing values to true (e.g. `--tags --other-flag`)
   if (value === true) {
@@ -450,6 +484,34 @@ function getRequiredStringArgFromParsed(parsed, key, aliases = []) {
   }
 
   return String(value);
+}
+
+function getOptionalStringArgFromParsed(parsed, key, aliases = []) {
+  const candidates = [key, ...aliases];
+
+  for (const candidate of candidates) {
+    if (!Object.prototype.hasOwnProperty.call(parsed, candidate)) continue;
+
+    const value = parsed[candidate];
+    const preferred = `--${key}`;
+    const aliasText = aliases.length > 0
+      ? ` (or ${aliases.map(a => `--${a}`).join(', ')})`
+      : '';
+
+    if (value === true) {
+      error(`${preferred}${aliasText} requires a value`);
+    }
+    if (typeof value !== 'string') {
+      error(`${preferred}${aliasText} must be a string`);
+    }
+    if (value.trim() === '') {
+      error(`${preferred}${aliasText} requires a non-empty value`);
+    }
+
+    return String(value);
+  }
+
+  return null;
 }
 
 function resolveSocialSetIdFromParsed(parsed, positionalId) {
@@ -579,6 +641,32 @@ async function cmdAnalyticsPostsList(args) {
   if (includeReplies) params.set('include_replies', 'true');
 
   const data = await apiRequest('GET', `/social-sets/${socialSetId}/analytics/${platform}/posts?${params}`);
+  output(data);
+}
+
+async function cmdAnalyticsFollowersGet(args) {
+  const parsed = parseArgs(args);
+  const socialSetId = resolveSocialSetIdFromParsed(parsed, parsed._positional[0]);
+  const platform = (parsed.platform
+    ? coerceFlagValueToString(parsed.platform, '--platform')
+    : 'x').toLowerCase();
+  const startDate = getOptionalStringArgFromParsed(parsed, 'start-date', ['start_date']);
+  const endDate = getOptionalStringArgFromParsed(parsed, 'end-date', ['end_date']);
+
+  if (platform !== 'x') {
+    error('Only X analytics are currently supported by the Typefully API', {
+      provided_platform: platform,
+      hint: 'Use --platform x or omit the flag',
+    });
+  }
+
+  const params = new URLSearchParams();
+  if (startDate) params.set('start_date', startDate);
+  if (endDate) params.set('end_date', endDate);
+  const query = params.toString();
+  const endpoint = `/social-sets/${socialSetId}/analytics/${platform}/followers${query ? `?${query}` : ''}`;
+
+  const data = await apiRequest('GET', endpoint);
   output(data);
 }
 
@@ -989,9 +1077,17 @@ async function getAllConnectedPlatforms(socialSetId) {
 }
 
 async function cmdDraftsCreate(args) {
-  const parsed = parseArgs(args, { share: 'boolean', all: 'boolean' });
+  const parsed = parseArgs(args, {
+    share: 'boolean',
+    all: 'boolean',
+    'paid-partnership': 'boolean',
+    paid_partnership: 'boolean',
+    'made-with-ai': 'boolean',
+    made_with_ai: 'boolean',
+  });
   const socialSetId = resolveSocialSetIdFromParsed(parsed, parsed._positional[0]);
   const quotePostUrl = getQuotePostUrlFromParsed(parsed);
+  const xContentDisclosures = getXContentDisclosuresFromParsed(parsed);
 
   // Get text content
   let text = parsed.text;
@@ -1030,9 +1126,10 @@ async function cmdDraftsCreate(args) {
   }
 
   const platformList = platforms.split(',').map(p => p.trim());
-  if (quotePostUrl && !platformList.includes('x')) {
-    error('--quote-post-url is only supported for X posts. Include x in --platform or remove the quote flag.');
-  }
+  validateXOnlyPostOptions(platformList, {
+    quotePostUrl,
+    disclosures: xContentDisclosures,
+  });
 
   // Split text into posts (thread support)
   const posts = splitThreadText(text);
@@ -1054,7 +1151,7 @@ async function cmdDraftsCreate(args) {
   const platformsObj = {};
   for (const platform of platformList) {
     const postsArray = platform === 'x'
-      ? addQuotePostUrl(basePostsArray, quotePostUrl)
+      ? addXContentDisclosures(addQuotePostUrl(basePostsArray, quotePostUrl), xContentDisclosures)
       : basePostsArray;
     const platformConfig = {
       enabled: true,
@@ -1103,9 +1200,18 @@ async function cmdDraftsCreate(args) {
 }
 
 async function cmdDraftsUpdate(args) {
-  const parsed = parseArgs(args, { append: 'boolean', share: 'boolean', 'use-default': 'boolean' });
+  const parsed = parseArgs(args, {
+    append: 'boolean',
+    share: 'boolean',
+    'use-default': 'boolean',
+    'paid-partnership': 'boolean',
+    paid_partnership: 'boolean',
+    'made-with-ai': 'boolean',
+    made_with_ai: 'boolean',
+  });
   const { socialSetId, draftId } = resolveDraftTargetFromParsed(parsed, 'drafts:update');
   const quotePostUrl = getQuotePostUrlFromParsed(parsed);
+  const xContentDisclosures = getXContentDisclosuresFromParsed(parsed);
 
   // Get text content
   let text = parsed.text;
@@ -1118,13 +1224,16 @@ async function cmdDraftsUpdate(args) {
 
   const body = {};
 
-  const shouldUpdatePosts = Boolean(text || quotePostUrl);
+  const shouldUpdatePosts = Boolean(text || quotePostUrl || xContentDisclosures.hasAny);
   if (shouldUpdatePosts) {
     const explicitPlatformList = parsed.platform
       ? parsed.platform.split(',').map(p => p.trim())
       : null;
-    if (quotePostUrl && explicitPlatformList && !explicitPlatformList.includes('x')) {
-      error('--quote-post-url is only supported for X posts. Include x in --platform or remove the quote flag.');
+    if (explicitPlatformList) {
+      validateXOnlyPostOptions(explicitPlatformList, {
+        quotePostUrl,
+        disclosures: xContentDisclosures,
+      });
     }
 
     // Parse media IDs
@@ -1154,9 +1263,10 @@ async function cmdDraftsUpdate(args) {
       }
     }
 
-    if (quotePostUrl && !platformList.includes('x')) {
-      error('--quote-post-url is only supported for X posts. Include x in --platform or remove the quote flag.');
-    }
+    validateXOnlyPostOptions(platformList, {
+      quotePostUrl,
+      disclosures: xContentDisclosures,
+    });
 
     let postsArray;
 
@@ -1189,10 +1299,13 @@ async function cmdDraftsUpdate(args) {
         });
       }
     } else {
-      // Quote-only update: preserve existing X posts and add quote URL.
+      // X-only metadata update: preserve existing X posts and add quote/disclosure attrs.
       const existingXPosts = existing.platforms?.x?.posts;
       if (!Array.isArray(existingXPosts) || existingXPosts.length === 0) {
-        error('Cannot apply --quote-post-url because this draft has no existing X posts');
+        if (quotePostUrl && !xContentDisclosures.hasAny) {
+          error('Cannot apply --quote-post-url because this draft has no existing X posts');
+        }
+        error('Cannot apply X-only post options because this draft has no existing X posts');
       }
       postsArray = existingXPosts;
       platformList = ['x'];
@@ -1202,7 +1315,7 @@ async function cmdDraftsUpdate(args) {
     const platformsObj = {};
     for (const p of platformList) {
       const platformPosts = p === 'x'
-        ? addQuotePostUrl(postsArray, quotePostUrl)
+        ? addXContentDisclosures(addQuotePostUrl(postsArray, quotePostUrl), xContentDisclosures)
         : postsArray;
       platformsObj[p] = {
         enabled: true,
@@ -1233,7 +1346,7 @@ async function cmdDraftsUpdate(args) {
   }
 
   if (Object.keys(body).length === 0) {
-    error('At least one of --text, --file, --title, --schedule, --share, --notes, --tags, or --quote-post-url is required');
+    error('At least one of --text, --file, --title, --schedule, --share, --notes, --tags, --quote-post-url, --paid-partnership, or --made-with-ai is required');
   }
 
   const data = await apiRequest('PATCH', `/social-sets/${socialSetId}/drafts/${draftId}`, body);
@@ -1245,7 +1358,14 @@ async function cmdDraftsUpdate(args) {
 // ---------------------------------------------------------------------------
 
 async function cmdCreateDraftAlias(args) {
-  const parsed = parseArgs(args, { share: 'boolean', all: 'boolean' });
+  const parsed = parseArgs(args, {
+    share: 'boolean',
+    all: 'boolean',
+    'paid-partnership': 'boolean',
+    paid_partnership: 'boolean',
+    'made-with-ai': 'boolean',
+    made_with_ai: 'boolean',
+  });
   const socialSetId = requireSocialSetId(getSocialSetIdFromParsed(parsed));
 
   const forwarded = [String(socialSetId)];
@@ -1276,6 +1396,8 @@ async function cmdCreateDraftAlias(args) {
   pushStringFlag(forwarded, parsed, 'community', '--community');
   const quotePostUrl = getQuotePostUrlFromParsed(parsed);
   if (quotePostUrl) forwarded.push('--quote-post-url', quotePostUrl);
+  if (parsed['paid-partnership'] || parsed.paid_partnership) forwarded.push('--paid-partnership');
+  if (parsed['made-with-ai'] || parsed.made_with_ai) forwarded.push('--made-with-ai');
   if (parsed.share) forwarded.push('--share');
   pushStringFlag(forwarded, parsed, 'notes', '--notes');
 
@@ -1283,7 +1405,14 @@ async function cmdCreateDraftAlias(args) {
 }
 
 async function cmdUpdateDraftAlias(args) {
-  const parsed = parseArgs(args, { append: 'boolean', share: 'boolean' });
+  const parsed = parseArgs(args, {
+    append: 'boolean',
+    share: 'boolean',
+    'paid-partnership': 'boolean',
+    paid_partnership: 'boolean',
+    'made-with-ai': 'boolean',
+    made_with_ai: 'boolean',
+  });
   const socialSetId = requireSocialSetId(getSocialSetIdFromParsed(parsed));
 
   if (parsed._positional.length === 0) {
@@ -1313,6 +1442,8 @@ async function cmdUpdateDraftAlias(args) {
   pushStringFlag(forwarded, parsed, 'tags', '--tags', { allowEmpty: true });
   const quotePostUrl = getQuotePostUrlFromParsed(parsed);
   if (quotePostUrl) forwarded.push('--quote-post-url', quotePostUrl);
+  if (parsed['paid-partnership'] || parsed.paid_partnership) forwarded.push('--paid-partnership');
+  if (parsed['made-with-ai'] || parsed.made_with_ai) forwarded.push('--made-with-ai');
   if (parsed.share) forwarded.push('--share');
   pushStringFlag(forwarded, parsed, 'notes', '--notes');
 
@@ -1585,6 +1716,13 @@ COMMANDS:
     --include-replies, --include_replies     Include X replies in results (excluded by default)
     --limit <n>                              Max results per page (default: 25, max: 100)
     --offset <n>                             Number of results to skip (default: 0)
+  analytics:followers:get [social_set_id] [options]
+                                             Get daily X follower counts (uses default if ID omitted)
+    --platform <platform>                    Platform to query (default: x; currently only x is supported)
+    --start-date <YYYY-MM-DD>                Inclusive start date (optional; default is last 30 days)
+                                             Also accepts: --start_date
+    --end-date <YYYY-MM-DD>                  Inclusive end date (optional; default is today)
+                                             Also accepts: --end_date
 
   drafts:list [social_set_id] [options]      List drafts (uses default if ID omitted)
     --status <status>                        Filter by: draft, scheduled, published, error, publishing
@@ -1609,6 +1747,8 @@ COMMANDS:
     --reply-to <url>                         URL of X post to reply to
     --community <id>                         X community ID to post to
     --quote-post-url, --quote-url <url>      Quote an X post URL (X only)
+    --paid-partnership, --paid_partnership   Label X posts as paid partnership
+    --made-with-ai, --made_with_ai           Label X posts as made with AI
     --share                                  Generate a public share URL for the draft
     --notes, --scratchpad <text>             Internal notes/scratchpad for the draft
 
@@ -1623,6 +1763,8 @@ COMMANDS:
     --schedule <time>                        "now", "next-free-slot", or ISO datetime
     --tags <tag_slugs>                       Comma-separated tag slugs
     --quote-post-url, --quote-url <url>      Quote an X post URL (X only)
+    --paid-partnership, --paid_partnership   Label X posts as paid partnership
+    --made-with-ai, --made_with_ai           Label X posts as made with AI
     --share                                  Generate a public share URL for the draft
     --notes, --scratchpad <text>             Internal notes/scratchpad for the draft
     --use-default                            Required when using default social set with single arg
@@ -1699,6 +1841,12 @@ EXAMPLES:
   # Include replies in X analytics results
   ./typefully.js analytics:posts:list --start-date 2026-03-01 --end-date 2026-03-07 --include-replies
 
+  # Fetch X followers analytics for the default last 30 days
+  ./typefully.js analytics:followers:get 123
+
+  # Fetch X followers analytics for a date range
+  ./typefully.js analytics:followers:get 123 --start-date 2026-03-01 --end-date 2026-03-31
+
   # Use resolved mention syntax in a LinkedIn draft
   ./typefully.js drafts:create 123 --platform linkedin --text "Thanks @[Typefully](urn:li:organization:86779668) for the support."
 
@@ -1759,6 +1907,9 @@ EXAMPLES:
   # Create a quote post on X
   ./typefully.js drafts:create 123 --platform x --text "My take on this" --quote-post-url "https://x.com/user/status/1234567890123456789"
 
+  # Create an X post with content disclosure labels
+  ./typefully.js drafts:create 123 --platform x --text "Sponsored AI-assisted update" --paid-partnership --made-with-ai
+
   # Update an X draft to quote a post
   ./typefully.js drafts:update 123 456 --platform x --text "Updated take" --quote-post-url "https://x.com/user/status/1234567890123456789"
 
@@ -1791,6 +1942,7 @@ const COMMANDS = {
   'social-sets:get': cmdSocialSetsGet,
   'linkedin:organizations:resolve': cmdLinkedInOrganizationsResolve,
   'analytics:posts:list': cmdAnalyticsPostsList,
+  'analytics:followers:get': cmdAnalyticsFollowersGet,
   'drafts:list': cmdDraftsList,
   'drafts:get': cmdDraftsGet,
   'drafts:create': cmdDraftsCreate,

--- a/tests/analytics.test.js
+++ b/tests/analytics.test.js
@@ -1,0 +1,70 @@
+const {
+  describe,
+  it,
+  assert,
+  withCliHarness,
+  authAssertFactory,
+  expectCliOk,
+  expectCliError,
+} = require('./typefully-cli.test-helpers');
+
+function queryParams(req) {
+  return new URL(`http://x${req.path}${req.search}`).searchParams;
+}
+
+describe('analytics:followers:get', () => {
+  it('fetches X follower analytics with optional date range', withCliHarness(async ({ server, apiKey, run }) => {
+    server.expect('GET', '/v2/social-sets/9/analytics/x/followers', {
+      assert: (req) => {
+        authAssertFactory(apiKey)(req);
+        const q = queryParams(req);
+        assert.equal(q.get('start_date'), '2026-03-01');
+        assert.equal(q.get('end_date'), '2026-03-31');
+      },
+      json: {
+        platform: 'x',
+        current_followers_count: 1500,
+        data: [{ date: '2026-03-31', followers_count: 1500 }],
+      },
+    });
+
+    const result = await run([
+      'analytics:followers:get',
+      '9',
+      '--start-date',
+      '2026-03-01',
+      '--end-date',
+      '2026-03-31',
+    ]);
+
+    expectCliOk(result, {
+      platform: 'x',
+      current_followers_count: 1500,
+      data: [{ date: '2026-03-31', followers_count: 1500 }],
+    });
+  }));
+
+  it('omits date query params when default range is requested', withCliHarness(async ({ server, apiKey, run }) => {
+    server.expect('GET', '/v2/social-sets/9/analytics/x/followers', {
+      assert: (req) => {
+        authAssertFactory(apiKey)(req);
+        assert.equal(req.search, '');
+      },
+      json: { platform: 'x', current_followers_count: null, data: [] },
+    });
+
+    const result = await run(['analytics:followers:get', '9']);
+    expectCliOk(result, { platform: 'x', current_followers_count: null, data: [] });
+  }));
+
+  it('rejects unsupported analytics platforms before making requests', withCliHarness(async ({ server, run }) => {
+    const result = await run(['analytics:followers:get', '9', '--platform', 'linkedin']);
+
+    expectCliError(result, {
+      error: 'Only X analytics are currently supported by the Typefully API',
+      provided_platform: 'linkedin',
+      hint: 'Use --platform x or omit the flag',
+    });
+    assert.equal(server.requests.length, 0);
+  }));
+});

--- a/tests/drafts.test.js
+++ b/tests/drafts.test.js
@@ -314,7 +314,7 @@ describe('drafts', () => {
     );
     assert.equal(result.code, 1);
     assert.deepEqual(parseJsonOrNull(result.stdout), {
-      error: 'At least one of --text, --file, --title, --schedule, --share, --notes, --tags, or --quote-post-url is required',
+      error: 'At least one of --text, --file, --title, --schedule, --share, --notes, --tags, --quote-post-url, --paid-partnership, or --made-with-ai is required',
     });
     assert.equal(server.requests.length, 0);
   }));
@@ -562,6 +562,36 @@ describe('drafts', () => {
     server.assertNoPendingExpectations();
   }));
 
+  it('drafts:create applies X content disclosures only to X posts', withCliHarness(async ({
+    sandbox, server, baseUrl, apiKey
+  }) => {
+  server.expect('POST', '/v2/social-sets/9/drafts', {
+    assert: (req) => {
+      authAssertFactory(apiKey)(req);
+      assert.deepEqual(req.bodyJson, {
+        platforms: {
+          x: {
+            enabled: true,
+            posts: [{ text: 'Sponsored AI update', paid_partnership: true, made_with_ai: true }],
+          },
+          linkedin: {
+            enabled: true,
+            posts: [{ text: 'Sponsored AI update' }],
+          },
+        },
+      });
+    },
+    json: { id: 'd1' },
+  });
+    const result = await runCli(
+      ['drafts:create', '9', '--platform', 'x,linkedin', '--text', 'Sponsored AI update', '--paid-partnership', '--made-with-ai'],
+      { cwd: sandbox.cwd, env: { HOME: sandbox.home, TYPEFULLY_API_BASE: baseUrl, TYPEFULLY_API_KEY: apiKey } }
+    );
+    assert.equal(result.code, 0);
+    assert.deepEqual(parseJsonOrNull(result.stdout), { id: 'd1' });
+    server.assertNoPendingExpectations();
+  }));
+
   it('drafts:create errors when quote URL is used without X platform', withCliHarness(async ({
     sandbox, server 
   }) => {
@@ -572,6 +602,20 @@ describe('drafts', () => {
     assert.equal(result.code, 1);
     assert.deepEqual(parseJsonOrNull(result.stdout), {
       error: '--quote-post-url is only supported for X posts. Include x in --platform or remove the quote flag.',
+    });
+    assert.equal(server.requests.length, 0);
+  }));
+
+  it('drafts:create errors when X content disclosures are used without X platform', withCliHarness(async ({
+    sandbox, server
+  }) => {
+  const result = await runCli(
+      ['drafts:create', '9', '--platform', 'linkedin', '--text', 'Hello', '--made-with-ai'],
+      { cwd: sandbox.cwd, env: { HOME: sandbox.home, TYPEFULLY_API_KEY: 'typ_test_key' } }
+    );
+    assert.equal(result.code, 1);
+    assert.deepEqual(parseJsonOrNull(result.stdout), {
+      error: '--paid-partnership/--made-with-ai is only supported for X posts. Include x in --platform or remove the X-only flag.',
     });
     assert.equal(server.requests.length, 0);
   }));
@@ -951,6 +995,48 @@ describe('drafts', () => {
   });
     const result = await runCli(
       ['drafts:update', '9', 'd1', '--quote-url', quoteUrl],
+      { cwd: sandbox.cwd, env: { HOME: sandbox.home, TYPEFULLY_API_BASE: baseUrl, TYPEFULLY_API_KEY: apiKey } }
+    );
+    assert.equal(result.code, 0);
+    assert.deepEqual(parseJsonOrNull(result.stdout), { id: 'd1', ok: true });
+    server.assertNoPendingExpectations();
+  }));
+
+  it('drafts:update can set X content disclosures without changing text', withCliHarness(async ({
+    sandbox, server, baseUrl, apiKey
+  }) => {
+  server.expect('GET', '/v2/social-sets/9/drafts/d1', {
+    assert: authAssertFactory(apiKey),
+    json: {
+      id: 'd1',
+      platforms: {
+        x: {
+          enabled: true,
+          posts: [{ text: 'Existing 1' }, { text: 'Existing 2' }],
+        },
+      },
+    },
+  });
+
+  server.expect('PATCH', '/v2/social-sets/9/drafts/d1', {
+    assert: (req) => {
+      authAssertFactory(apiKey)(req);
+      assert.deepEqual(req.bodyJson, {
+        platforms: {
+          x: {
+            enabled: true,
+            posts: [
+              { text: 'Existing 1', made_with_ai: true },
+              { text: 'Existing 2', made_with_ai: true },
+            ],
+          },
+        },
+      });
+    },
+    json: { id: 'd1', ok: true },
+  });
+    const result = await runCli(
+      ['drafts:update', '9', 'd1', '--made-with-ai'],
       { cwd: sandbox.cwd, env: { HOME: sandbox.home, TYPEFULLY_API_BASE: baseUrl, TYPEFULLY_API_KEY: apiKey } }
     );
     assert.equal(result.code, 0);


### PR DESCRIPTION
## Summary
- add `analytics:followers:get` for X follower counts with optional date filters
- support X content disclosure flags on draft create/update
- document publishing quota awareness via `social-sets:get` and refresh the skill changelog/date

## Validation
- `node --check skills/typefully/scripts/typefully.js`
- `./skills/typefully/scripts/typefully.js --help`
- `npm test -- tests/analytics.test.js tests/drafts.test.js tests/social-sets.test.js`
- `npm test -- tests/*.test.js`