### PR TITLE
feat(typefully): add LinkedIn first comment support to drafts

### DIFF
--- a/skills/typefully/CHANGELOG.md
+++ b/skills/typefully/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on Keep a Changelog.
 
 ### Added
 
-- LinkedIn first comment support: `drafts:create`/`drafts:update` accept `--linkedin-first-comment <text>` to post a plain-text comment right after the LinkedIn post is published (the "link in the first comment" pattern). On update, a literal `null` removes the comment and omitting the flag preserves it — including on text-only updates, where the CLI re-sends the existing comment so the API doesn't clear it.
+- LinkedIn first comment support: `drafts:create`/`drafts:update` accept `--linkedin-first-comment <text>` to post a plain-text comment right after the LinkedIn post is published (the "link in the first comment" pattern). On update, a literal `null` removes the comment and omitting the flag preserves it.
 - Aliases: `--linkedin_first_comment`, `--first-comment`, `--first_comment`.
 - Documented in `SKILL.md` (flags table, common actions) and `references/platforms/linkedin.md`.
 

--- a/skills/typefully/CHANGELOG.md
+++ b/skills/typefully/CHANGELOG.md
@@ -4,7 +4,13 @@ All notable user-facing changes to the Typefully skill and its CLI are documente
 
 The format is based on Keep a Changelog.
 
-## 2026-07-09
+## 2026-07-10
+
+### Added
+
+- LinkedIn first comment support: `drafts:create`/`drafts:update` accept `--linkedin-first-comment <text>` to post a plain-text comment right after the LinkedIn post is published (the "link in the first comment" pattern). On update, a literal `null` removes the comment and omitting the flag preserves it — including on text-only updates, where the CLI re-sends the existing comment so the API doesn't clear it.
+- Aliases: `--linkedin_first_comment`, `--first-comment`, `--first_comment`.
+- Documented in `SKILL.md` (flags table, common actions) and `references/platforms/linkedin.md`.
 
 ### Changed
 

--- a/skills/typefully/SKILL.md
+++ b/skills/typefully/SKILL.md
@@ -6,7 +6,7 @@ description: >
   social media content for Twitter/X, LinkedIn, Threads, Bluesky, or Mastodon,
   or when the user drops a Typefully draft URL such as
   https://typefully.com/?a=<social_set_id>&d=<draft_id>.
-last-updated: 2026-07-09
+last-updated: 2026-07-10
 allowed-tools: Bash(./scripts/typefully.js:*)
 ---
 
@@ -135,6 +135,7 @@ When the user asks to add notes, ideas, or context to a draft, use `--scratchpad
 | "Check my publishing quota" | `social-sets:get` → `publishing_quota` |
 | "Draft an X Article" | See [`references/platforms/x-articles.md`](references/platforms/x-articles.md) |
 | "Mention a company on LinkedIn" | See [`references/platforms/linkedin.md`](references/platforms/linkedin.md) |
+| "Put the link in a LinkedIn first comment" | `drafts:create --platform linkedin --text "..." --linkedin-first-comment "..."` |
 | "Show my X analytics / followers" | See [`references/platforms/x.md`](references/platforms/x.md) |
 | "Comment on / resolve a comment" | See [`references/comments.md`](references/comments.md) |
 
@@ -183,6 +184,7 @@ Add any of these flags to a `drafts:create` or `drafts:update` command. The **Ap
 | `--scratchpad "<notes>"` | Attach internal notes (see [Scratchpad notes](#scratchpad-notes)) | create, update |
 | `--share` | Generate a public share URL | create, update |
 | `--schedule <iso\|next-free-slot\|now>` | Schedule or reschedule the draft | create, update |
+| `--linkedin-first-comment "<text>"` | LinkedIn first comment, posted right after publishing (`null` removes it on update) | create, update |
 | `--exclude-comment-markers` | Render response without anchors (display only; validation still applies) | update |
 | `--force-overwrite-comments` | Destructive last resort — see [`comments.md`](references/comments.md) | update |
 
@@ -193,7 +195,7 @@ For example, combine the base command with flags like this:
 ./scripts/typefully.js drafts:update 456 --text "Revised copy" --media abc-123 --use-default
 ```
 
-> X-only draft flags (`--reply-to`, `--quote-post-url`, `--community`, `--paid-partnership`, `--made-with-ai`): see [`platforms/x.md`](references/platforms/x.md). X Article flags (`--content-markdown`, `--cover-media-id`): see [`platforms/x-articles.md`](references/platforms/x-articles.md).
+> X-only draft flags (`--reply-to`, `--quote-post-url`, `--community`, `--paid-partnership`, `--made-with-ai`): see [`platforms/x.md`](references/platforms/x.md). LinkedIn-only flags (`--linkedin-first-comment`): see [`platforms/linkedin.md`](references/platforms/linkedin.md). X Article flags (`--content-markdown`, `--cover-media-id`): see [`platforms/x-articles.md`](references/platforms/x-articles.md).
 
 ### Scheduling & publishing
 

--- a/skills/typefully/references/platforms/linkedin.md
+++ b/skills/typefully/references/platforms/linkedin.md
@@ -26,3 +26,22 @@ Then include the returned `mention_text` in the draft:
 `linkedin:organizations:resolve [social_set_id] --organization-url <url>` returns `mention_text` and `urn`.
 
 > When commenting on text that contains a mention, select the entire `@[Name](urn:li:...)` substring or stay fully outside it.
+
+## First comment
+
+Post a comment right after the LinkedIn post is published — the common "link in the first comment" pattern:
+
+```bash
+./scripts/typefully.js drafts:create --platform linkedin --text "Big launch today!" --linkedin-first-comment "Full details: https://example.com/launch"
+```
+
+On `drafts:update`, the flag sets or replaces the comment; a literal `null` removes it; omitting the flag keeps the current comment:
+
+```bash
+./scripts/typefully.js drafts:update 123 d456 --linkedin-first-comment "Link here: https://example.com"
+./scripts/typefully.js drafts:update 123 d456 --linkedin-first-comment null
+```
+
+- Plain text only: newlines are preserved and LinkedIn renders URLs as links, but mention syntax is **not** supported inside comments.
+- Aliases: `--linkedin_first_comment`, `--first-comment`, `--first_comment`.
+- Draft responses expose it as `platforms.linkedin.settings.first_comment`.

--- a/skills/typefully/scripts/typefully.js
+++ b/skills/typefully/scripts/typefully.js
@@ -451,6 +451,48 @@ function addQuotePostUrl(posts, quotePostUrl) {
   return posts.map(post => ({ ...post, quote_post_url: quotePostUrl }));
 }
 
+// LinkedIn first comment: a plain-text comment Typefully posts right after the
+// LinkedIn post is published. Returns { provided, value } where value === null
+// means "clear the first comment" (literal null, same convention as
+// --cover-media-id).
+function getLinkedInFirstCommentFromParsed(parsed) {
+  const keys = ['linkedin-first-comment', 'linkedin_first_comment', 'first-comment', 'first_comment'];
+  const found = [];
+  for (const key of keys) {
+    if (Object.prototype.hasOwnProperty.call(parsed, key)) {
+      found.push({ key, value: coerceFlagValueToString(parsed[key], `--${key}`, { allowEmpty: true }) });
+    }
+  }
+
+  if (found.length === 0) return { provided: false, value: null };
+
+  const primary = found[0].value;
+  for (const entry of found) {
+    if (entry.value !== primary) {
+      error('Conflicting LinkedIn first comment values', Object.fromEntries(found.map(e => [`--${e.key}`, e.value])));
+    }
+  }
+
+  if (primary.trim() === '' || primary.trim().toLowerCase() === 'null') {
+    return { provided: true, value: null };
+  }
+  return { provided: true, value: primary };
+}
+
+function buildLinkedInSettingsForUpdate(firstComment, existing) {
+  if (firstComment.provided) {
+    // Explicit set or clear (literal null).
+    return { first_comment: firstComment.value };
+  }
+  // Flag omitted: re-send the existing first comment so a text-only update
+  // doesn't clear it (the API clears LinkedIn settings when omitted).
+  const existingFirstComment = existing?.platforms?.linkedin?.settings?.first_comment;
+  if (existingFirstComment) {
+    return { first_comment: existingFirstComment };
+  }
+  return null;
+}
+
 // Draft GET responses include response-only and platform-specific post fields
 // (e.g. subscribers_only, linkedin_reshare_urn) that the API's request schemas
 // reject with 422 on other platforms. Before re-sending fetched posts, keep only
@@ -509,6 +551,12 @@ function validateXOnlyPostOptions(platformList, { quotePostUrl, disclosures }) {
       error('--quote-post-url is only supported for X posts. Include x in --platform or remove the quote flag.');
     }
     error('--paid-partnership/--made-with-ai is only supported for X posts. Include x in --platform or remove the X-only flag.');
+  }
+}
+
+function validateLinkedInOnlyOptions(platformList, { firstComment }) {
+  if (firstComment.provided && !platformList.includes('linkedin')) {
+    error('--linkedin-first-comment is only supported for LinkedIn. Include linkedin in --platform or remove the flag.');
   }
 }
 
@@ -1264,6 +1312,7 @@ async function cmdDraftsCreate(args) {
   const socialSetId = resolveSocialSetIdFromParsed(parsed, parsed._positional[0]);
   const quotePostUrl = getQuotePostUrlFromParsed(parsed);
   const xContentDisclosures = getXContentDisclosuresFromParsed(parsed);
+  const linkedInFirstComment = getLinkedInFirstCommentFromParsed(parsed);
 
   // Determine platform(s)
   let platforms = parsed.platform;
@@ -1294,6 +1343,7 @@ async function cmdDraftsCreate(args) {
 
   const platformList = parsePlatformList(platforms);
   validateXArticlePlatformUsage(platformList, parsed);
+  validateLinkedInOnlyOptions(platformList, { firstComment: linkedInFirstComment });
 
   // Build request body
   const platformsObj = {};
@@ -1349,6 +1399,11 @@ async function cmdDraftsCreate(args) {
         }
       }
 
+      // LinkedIn-specific settings
+      if (platform === 'linkedin' && linkedInFirstComment.value) {
+        platformConfig.settings = { first_comment: linkedInFirstComment.value };
+      }
+
       platformsObj[platform] = platformConfig;
     }
   }
@@ -1396,6 +1451,7 @@ async function cmdDraftsUpdate(args) {
   const { socialSetId, draftId } = resolveDraftTargetFromParsed(parsed, 'drafts:update');
   const quotePostUrl = getQuotePostUrlFromParsed(parsed);
   const xContentDisclosures = getXContentDisclosuresFromParsed(parsed);
+  const linkedInFirstComment = getLinkedInFirstCommentFromParsed(parsed);
 
   const body = {};
   const explicitPlatformList = parsed.platform
@@ -1408,6 +1464,7 @@ async function cmdDraftsUpdate(args) {
 
   if (explicitPlatformList) {
     validateXArticlePlatformUsage(explicitPlatformList, parsed);
+    validateLinkedInOnlyOptions(explicitPlatformList, { firstComment: linkedInFirstComment });
   }
 
   const shouldUpdateArticle = Boolean(
@@ -1428,7 +1485,9 @@ async function cmdDraftsUpdate(args) {
     text = getPostTextFromParsed(parsed);
   }
 
-  const shouldUpdatePosts = Boolean(!shouldUpdateArticle && (text || quotePostUrl || xContentDisclosures.hasAny));
+  const shouldUpdatePosts = Boolean(
+    !shouldUpdateArticle && (text || quotePostUrl || xContentDisclosures.hasAny || linkedInFirstComment.provided)
+  );
   if (shouldUpdatePosts) {
     if (explicitPlatformList) {
       validateXOnlyPostOptions(explicitPlatformList, {
@@ -1469,8 +1528,10 @@ async function cmdDraftsUpdate(args) {
       quotePostUrl,
       disclosures: xContentDisclosures,
     });
+    validateLinkedInOnlyOptions(platformList, { firstComment: linkedInFirstComment });
 
     let postsArray;
+    let metadataOnlyPosts = null; // platform -> existing posts, for metadata-only updates
 
     if (text) {
       if (parsed.append) {
@@ -1501,22 +1562,37 @@ async function cmdDraftsUpdate(args) {
         });
       }
     } else {
-      // X-only metadata update: preserve existing X posts and add quote/disclosure attrs.
-      const existingXPosts = existing.platforms?.x?.posts;
-      if (!Array.isArray(existingXPosts) || existingXPosts.length === 0) {
-        if (quotePostUrl && !xContentDisclosures.hasAny) {
-          error('Cannot apply --quote-post-url because this draft has no existing X posts');
+      // Metadata-only update: preserve existing posts on the target platforms.
+      metadataOnlyPosts = {};
+      platformList = [];
+
+      if (quotePostUrl || xContentDisclosures.hasAny) {
+        const existingXPosts = existing.platforms?.x?.posts;
+        if (!Array.isArray(existingXPosts) || existingXPosts.length === 0) {
+          if (quotePostUrl && !xContentDisclosures.hasAny) {
+            error('Cannot apply --quote-post-url because this draft has no existing X posts');
+          }
+          error('Cannot apply X-only post options because this draft has no existing X posts');
         }
-        error('Cannot apply X-only post options because this draft has no existing X posts');
+        metadataOnlyPosts.x = existingXPosts;
+        platformList.push('x');
       }
-      postsArray = existingXPosts;
-      platformList = ['x'];
+
+      if (linkedInFirstComment.provided) {
+        const existingLinkedInPosts = existing.platforms?.linkedin?.posts;
+        if (!Array.isArray(existingLinkedInPosts) || existingLinkedInPosts.length === 0) {
+          error('Cannot apply --linkedin-first-comment because this draft has no existing LinkedIn posts');
+        }
+        metadataOnlyPosts.linkedin = existingLinkedInPosts;
+        platformList.push('linkedin');
+      }
     }
 
     // Build platforms object
     const platformsObj = {};
     for (const p of platformList) {
-      const sanitizedPosts = postsArray.map(post => sanitizePostForPlatform(post, p));
+      const sourcePosts = metadataOnlyPosts ? metadataOnlyPosts[p] : postsArray;
+      const sanitizedPosts = sourcePosts.map(post => sanitizePostForPlatform(post, p));
       const platformPosts = p === 'x'
         ? addXContentDisclosures(addQuotePostUrl(sanitizedPosts, quotePostUrl), xContentDisclosures)
         : sanitizedPosts;
@@ -1524,6 +1600,12 @@ async function cmdDraftsUpdate(args) {
         enabled: true,
         posts: platformPosts,
       };
+      if (p === 'linkedin') {
+        const linkedInSettings = buildLinkedInSettingsForUpdate(linkedInFirstComment, existing);
+        if (linkedInSettings) {
+          platformsObj[p].settings = linkedInSettings;
+        }
+      }
     }
     body.platforms = platformsObj;
   }
@@ -1553,7 +1635,7 @@ async function cmdDraftsUpdate(args) {
   }
 
   if (Object.keys(body).length === 0) {
-    error('At least one of --text, --file, --content-markdown, --cover-media-id, --title, --schedule, --share, --notes, --tags, --quote-post-url, --paid-partnership, --made-with-ai, or --force-overwrite-comments is required');
+    error('At least one of --text, --file, --content-markdown, --cover-media-id, --title, --schedule, --share, --notes, --tags, --quote-post-url, --linkedin-first-comment, --paid-partnership, --made-with-ai, or --force-overwrite-comments is required');
   }
 
   const params = new URLSearchParams();
@@ -1620,6 +1702,10 @@ async function cmdCreateDraftAlias(args) {
   pushStringFlag(forwarded, parsed, 'community', '--community');
   const quotePostUrl = getQuotePostUrlFromParsed(parsed);
   if (quotePostUrl) forwarded.push('--quote-post-url', quotePostUrl);
+  const linkedInFirstComment = getLinkedInFirstCommentFromParsed(parsed);
+  if (linkedInFirstComment.provided) {
+    forwarded.push('--linkedin-first-comment', linkedInFirstComment.value ?? 'null');
+  }
   if (parsed['paid-partnership'] || parsed.paid_partnership) forwarded.push('--paid-partnership');
   if (parsed['made-with-ai'] || parsed.made_with_ai) forwarded.push('--made-with-ai');
   if (parsed.share) forwarded.push('--share');
@@ -1668,6 +1754,10 @@ async function cmdUpdateDraftAlias(args) {
   pushStringFlag(forwarded, parsed, 'tags', '--tags', { allowEmpty: true });
   const quotePostUrl = getQuotePostUrlFromParsed(parsed);
   if (quotePostUrl) forwarded.push('--quote-post-url', quotePostUrl);
+  const linkedInFirstComment = getLinkedInFirstCommentFromParsed(parsed);
+  if (linkedInFirstComment.provided) {
+    forwarded.push('--linkedin-first-comment', linkedInFirstComment.value ?? 'null');
+  }
   if (parsed['paid-partnership'] || parsed.paid_partnership) forwarded.push('--paid-partnership');
   if (parsed['made-with-ai'] || parsed.made_with_ai) forwarded.push('--made-with-ai');
   if (parsed.share) forwarded.push('--share');
@@ -2152,6 +2242,9 @@ COMMANDS:
     --reply-to <url>                         URL of X post to reply to
     --community <id>                         X community ID to post to
     --quote-post-url, --quote-url <url>      Quote an X post URL (X only)
+    --linkedin-first-comment <text>          Plain-text comment posted right after the LinkedIn
+                                             post is published (LinkedIn only, no mention syntax).
+                                             Also accepts: --first-comment
     --paid-partnership, --paid_partnership   Label X posts as paid partnership
     --made-with-ai, --made_with_ai           Label X posts as made with AI
     --share                                  Generate a public share URL for the draft
@@ -2170,6 +2263,9 @@ COMMANDS:
     --schedule <time>                        "now", "next-free-slot", or ISO datetime
     --tags <tag_slugs>                       Comma-separated tag slugs
     --quote-post-url, --quote-url <url>      Quote an X post URL (X only)
+    --linkedin-first-comment <text|null>     Set the LinkedIn first comment; use literal null to
+                                             remove it. Omitting the flag keeps the current comment.
+                                             Also accepts: --first-comment
     --paid-partnership, --paid_partnership   Label X posts as paid partnership
     --made-with-ai, --made_with_ai           Label X posts as made with AI
     --share                                  Generate a public share URL for the draft
@@ -2296,6 +2392,15 @@ EXAMPLES:
 
   # Use resolved mention syntax in a LinkedIn draft
   ./typefully.js drafts:create 123 --platform linkedin --text "Thanks @[Typefully](urn:li:organization:86779668) for the support."
+
+  # Create a LinkedIn post with a first comment (posted right after publishing)
+  ./typefully.js drafts:create 123 --platform linkedin --text "Big launch today!" --linkedin-first-comment "Full details: https://example.com/launch"
+
+  # Add or replace the first comment on an existing LinkedIn draft
+  ./typefully.js drafts:update 123 d456 --linkedin-first-comment "Link in this comment: https://example.com"
+
+  # Remove the first comment from a LinkedIn draft
+  ./typefully.js drafts:update 123 d456 --linkedin-first-comment null
 
   # Create a tweet (uses default social set if configured)
   ./typefully.js drafts:create --text "Hello world!"

--- a/skills/typefully/scripts/typefully.js
+++ b/skills/typefully/scripts/typefully.js
@@ -479,20 +479,6 @@ function getLinkedInFirstCommentFromParsed(parsed) {
   return { provided: true, value: primary };
 }
 
-function buildLinkedInSettingsForUpdate(firstComment, existing) {
-  if (firstComment.provided) {
-    // Explicit set or clear (literal null).
-    return { first_comment: firstComment.value };
-  }
-  // Flag omitted: re-send the existing first comment so a text-only update
-  // doesn't clear it (the API clears LinkedIn settings when omitted).
-  const existingFirstComment = existing?.platforms?.linkedin?.settings?.first_comment;
-  if (existingFirstComment) {
-    return { first_comment: existingFirstComment };
-  }
-  return null;
-}
-
 // Draft GET responses include response-only and platform-specific post fields
 // (e.g. subscribers_only, linkedin_reshare_urn) that the API's request schemas
 // reject with 422 on other platforms. Before re-sending fetched posts, keep only
@@ -1600,11 +1586,10 @@ async function cmdDraftsUpdate(args) {
         enabled: true,
         posts: platformPosts,
       };
-      if (p === 'linkedin') {
-        const linkedInSettings = buildLinkedInSettingsForUpdate(linkedInFirstComment, existing);
-        if (linkedInSettings) {
-          platformsObj[p].settings = linkedInSettings;
-        }
+      // The API preserves the LinkedIn first comment when settings are
+      // omitted, so only send them when the flag was passed (null clears).
+      if (p === 'linkedin' && linkedInFirstComment.provided) {
+        platformsObj[p].settings = { first_comment: linkedInFirstComment.value };
       }
     }
     body.platforms = platformsObj;

--- a/tests/drafts.test.js
+++ b/tests/drafts.test.js
@@ -426,7 +426,7 @@ describe('drafts', () => {
     );
     assert.equal(result.code, 1);
     assert.deepEqual(parseJsonOrNull(result.stdout), {
-      error: 'At least one of --text, --file, --content-markdown, --cover-media-id, --title, --schedule, --share, --notes, --tags, --quote-post-url, --paid-partnership, --made-with-ai, or --force-overwrite-comments is required',
+      error: 'At least one of --text, --file, --content-markdown, --cover-media-id, --title, --schedule, --share, --notes, --tags, --quote-post-url, --linkedin-first-comment, --paid-partnership, --made-with-ai, or --force-overwrite-comments is required',
     });
     assert.equal(server.requests.length, 0);
   }));
@@ -654,8 +654,195 @@ describe('drafts', () => {
     server.assertNoPendingExpectations();
   }));
 
+  it('drafts:create sends LinkedIn first comment as settings only on LinkedIn', withCliHarness(async ({
+    sandbox, server, baseUrl, apiKey
+  }) => {
+  server.expect('POST', '/v2/social-sets/9/drafts', {
+    assert: (req) => {
+      authAssertFactory(apiKey)(req);
+      assert.deepEqual(req.bodyJson, {
+        platforms: {
+          x: {
+            enabled: true,
+            posts: [{ text: 'Big launch today!' }],
+          },
+          linkedin: {
+            enabled: true,
+            posts: [{ text: 'Big launch today!' }],
+            settings: { first_comment: 'Full details: https://example.com/launch' },
+          },
+        },
+      });
+    },
+    json: { id: 'd1' },
+  });
+    const result = await runCli(
+      [
+        'drafts:create',
+        '9',
+        '--platform',
+        'x,linkedin',
+        '--text',
+        'Big launch today!',
+        '--linkedin-first-comment',
+        'Full details: https://example.com/launch',
+      ],
+      { cwd: sandbox.cwd, env: { HOME: sandbox.home, TYPEFULLY_API_BASE: baseUrl, TYPEFULLY_API_KEY: apiKey } }
+    );
+    assert.equal(result.code, 0);
+    assert.deepEqual(parseJsonOrNull(result.stdout), { id: 'd1' });
+    server.assertNoPendingExpectations();
+  }));
+
+  it('drafts:create errors when --linkedin-first-comment is used without LinkedIn platform', withCliHarness(async ({
+    sandbox, server, baseUrl
+  }) => {
+    const result = await runCli(
+      ['drafts:create', '9', '--platform', 'x', '--text', 'Hello', '--linkedin-first-comment', 'A comment'],
+      { cwd: sandbox.cwd, env: { HOME: sandbox.home, TYPEFULLY_API_BASE: baseUrl, TYPEFULLY_API_KEY: 'typ_test_key' } }
+    );
+    assert.equal(result.code, 1);
+    assert.deepEqual(parseJsonOrNull(result.stdout), {
+      error: '--linkedin-first-comment is only supported for LinkedIn. Include linkedin in --platform or remove the flag.',
+    });
+    assert.equal(server.requests.length, 0);
+  }));
+
+  it('drafts:update sets LinkedIn first comment without --text (preserves existing posts)', withCliHarness(async ({
+    sandbox, server, baseUrl, apiKey
+  }) => {
+  server.expect('GET', '/v2/social-sets/9/drafts/d1', {
+    assert: authAssertFactory(apiKey),
+    json: {
+      id: 'd1',
+      platforms: {
+        linkedin: { enabled: true, posts: [{ text: 'LI post', media_ids: [] }] },
+      },
+    },
+  });
+
+  server.expect('PATCH', '/v2/social-sets/9/drafts/d1', {
+    assert: (req) => {
+      authAssertFactory(apiKey)(req);
+      assert.deepEqual(req.bodyJson, {
+        platforms: {
+          linkedin: {
+            enabled: true,
+            posts: [{ text: 'LI post' }],
+            settings: { first_comment: 'Link here: https://example.com' },
+          },
+        },
+      });
+    },
+    json: { id: 'd1', ok: true },
+  });
+    // Uses the --first-comment alias.
+    const result = await runCli(
+      ['drafts:update', '9', 'd1', '--first-comment', 'Link here: https://example.com'],
+      { cwd: sandbox.cwd, env: { HOME: sandbox.home, TYPEFULLY_API_BASE: baseUrl, TYPEFULLY_API_KEY: apiKey } }
+    );
+    assert.equal(result.code, 0);
+    assert.deepEqual(parseJsonOrNull(result.stdout), { id: 'd1', ok: true });
+    server.assertNoPendingExpectations();
+  }));
+
+  it('drafts:update text-only update preserves the existing LinkedIn first comment', withCliHarness(async ({
+    sandbox, server, baseUrl, apiKey
+  }) => {
+  server.expect('GET', '/v2/social-sets/9/drafts/d1', {
+    assert: authAssertFactory(apiKey),
+    json: {
+      id: 'd1',
+      platforms: {
+        linkedin: {
+          enabled: true,
+          posts: [{ text: 'Old' }],
+          settings: { first_comment: 'Existing comment' },
+        },
+      },
+    },
+  });
+
+  server.expect('PATCH', '/v2/social-sets/9/drafts/d1', {
+    assert: (req) => {
+      authAssertFactory(apiKey)(req);
+      assert.deepEqual(req.bodyJson, {
+        platforms: {
+          linkedin: {
+            enabled: true,
+            posts: [{ text: 'New copy' }],
+            settings: { first_comment: 'Existing comment' },
+          },
+        },
+      });
+    },
+    json: { id: 'd1', ok: true },
+  });
+    const result = await runCli(
+      ['drafts:update', '9', 'd1', '--text', 'New copy'],
+      { cwd: sandbox.cwd, env: { HOME: sandbox.home, TYPEFULLY_API_BASE: baseUrl, TYPEFULLY_API_KEY: apiKey } }
+    );
+    assert.equal(result.code, 0);
+    assert.deepEqual(parseJsonOrNull(result.stdout), { id: 'd1', ok: true });
+    server.assertNoPendingExpectations();
+  }));
+
+  it('drafts:update --linkedin-first-comment null clears the first comment', withCliHarness(async ({
+    sandbox, server, baseUrl, apiKey
+  }) => {
+  server.expect('GET', '/v2/social-sets/9/drafts/d1', {
+    assert: authAssertFactory(apiKey),
+    json: {
+      id: 'd1',
+      platforms: {
+        linkedin: {
+          enabled: true,
+          posts: [{ text: 'LI post' }],
+          settings: { first_comment: 'Existing comment' },
+        },
+      },
+    },
+  });
+
+  server.expect('PATCH', '/v2/social-sets/9/drafts/d1', {
+    assert: (req) => {
+      authAssertFactory(apiKey)(req);
+      assert.deepEqual(req.bodyJson, {
+        platforms: {
+          linkedin: {
+            enabled: true,
+            posts: [{ text: 'LI post' }],
+            settings: { first_comment: null },
+          },
+        },
+      });
+    },
+    json: { id: 'd1', ok: true },
+  });
+    const result = await runCli(
+      ['drafts:update', '9', 'd1', '--linkedin-first-comment', 'null'],
+      { cwd: sandbox.cwd, env: { HOME: sandbox.home, TYPEFULLY_API_BASE: baseUrl, TYPEFULLY_API_KEY: apiKey } }
+    );
+    assert.equal(result.code, 0);
+    assert.deepEqual(parseJsonOrNull(result.stdout), { id: 'd1', ok: true });
+    server.assertNoPendingExpectations();
+  }));
+
+  it('drafts:update errors on conflicting first comment flag values', withCliHarness(async ({
+    sandbox, server, baseUrl
+  }) => {
+    const result = await runCli(
+      ['drafts:update', '9', 'd1', '--linkedin-first-comment', 'One', '--first-comment', 'Two'],
+      { cwd: sandbox.cwd, env: { HOME: sandbox.home, TYPEFULLY_API_BASE: baseUrl, TYPEFULLY_API_KEY: 'typ_test_key' } }
+    );
+    assert.equal(result.code, 1);
+    const parsed = parseJsonOrNull(result.stdout);
+    assert.equal(parsed.error, 'Conflicting LinkedIn first comment values');
+    assert.equal(server.requests.length, 0);
+  }));
+
   it('drafts:create accepts --quote-url alias', withCliHarness(async ({
-    sandbox, server, baseUrl, apiKey 
+    sandbox, server, baseUrl, apiKey
   }) => {
   const quoteUrl = 'https://x.com/typefullyapp/status/1234567890123456789';
   server.expect('POST', '/v2/social-sets/9/drafts', {

--- a/tests/drafts.test.js
+++ b/tests/drafts.test.js
@@ -746,7 +746,7 @@ describe('drafts', () => {
     server.assertNoPendingExpectations();
   }));
 
-  it('drafts:update text-only update preserves the existing LinkedIn first comment', withCliHarness(async ({
+  it('drafts:update text-only update omits LinkedIn settings (API preserves the first comment)', withCliHarness(async ({
     sandbox, server, baseUrl, apiKey
   }) => {
   server.expect('GET', '/v2/social-sets/9/drafts/d1', {
@@ -771,7 +771,6 @@ describe('drafts', () => {
           linkedin: {
             enabled: true,
             posts: [{ text: 'New copy' }],
-            settings: { first_comment: 'Existing comment' },
           },
         },
       });


### PR DESCRIPTION
## Summary

Adds LinkedIn **first comment** support to `drafts:create` and `drafts:update` — the common "link in the first comment" pattern. Pairs with the API v2 change in typefully/typefully-backend#1770.

```bash
./scripts/typefully.js drafts:create --platform linkedin --text "Big launch today!" --linkedin-first-comment "Full details: https://example.com/launch"
```

## CLI behavior

- New flag `--linkedin-first-comment <text>` on `drafts:create`/`drafts:update` (and the `create-draft`/`update-draft` aliases). Flag aliases: `--linkedin_first_comment`, `--first-comment`, `--first_comment`, with conflict detection when several are passed with different values.
- Sent to the API as `platforms.linkedin.settings.first_comment`. LinkedIn-only: using it without `linkedin` in the target platforms errors.
- On update:
  - literal `null` clears the comment;
  - omitting the flag preserves the existing comment — the CLI only sends `settings` when the flag is passed, and the API preserves the first comment when settings are omitted;
  - the flag alone (no `--text`) works as a settings-only update: the CLI re-sends the draft's existing LinkedIn posts, mirroring the X metadata-only update path.

## Docs & tests

- `SKILL.md`: flags table, common actions row, LinkedIn-only flags pointer, `last-updated` bump.
- `references/platforms/linkedin.md`: new "First comment" section.
- `CHANGELOG.md`: user-facing entry under 2026-07-10.
- 6 new tests in `tests/drafts.test.js` (create payload, platform validation, settings-only update, settings omitted on text-only update, null clear, conflicting flags); full suite passes (122 tests).

> Merge note: requires typefully/typefully-backend#1770 to be deployed first — the current API schema rejects `platforms.linkedin.settings.first_comment` with 422.